### PR TITLE
feat(frontend): replace any usages with typed interfaces

### DIFF
--- a/smart-campus-backend/package-lock.json
+++ b/smart-campus-backend/package-lock.json
@@ -2634,6 +2634,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "smart-campus-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite_react_shadcn_ts",
+      "name": "smart-campus-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
@@ -161,7 +161,6 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -313,6 +312,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -357,6 +357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2666,6 +2667,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -3229,7 +3231,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3249,7 +3250,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3258,8 +3258,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -3317,8 +3316,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3423,6 +3421,7 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3444,6 +3443,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3455,6 +3455,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3479,6 +3480,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
       "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3541,6 +3543,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3905,6 +3908,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4194,6 +4198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4683,6 +4688,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4747,7 +4753,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4832,7 +4837,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4992,6 +4998,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5946,6 +5953,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -6599,7 +6607,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6998,6 +7005,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7042,6 +7050,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7187,7 +7196,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7202,7 +7210,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7212,7 +7219,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7224,8 +7230,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -7294,6 +7299,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7332,6 +7338,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7345,6 +7352,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8084,6 +8092,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8150,7 +8159,8 @@
       "version": "0.160.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
       "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -8411,6 +8421,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8598,6 +8609,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/smart-campus-frontend/src/contexts/AuthContext.tsx
+++ b/smart-campus-frontend/src/contexts/AuthContext.tsx
@@ -1,17 +1,9 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 import { authService, RegisterRequest } from '@/services/authService';
+import { User, ApiError } from '@/types';
+import { AxiosError } from 'axios';
 
-interface User {
-  id: number;
-  full_name: string;
-  email: string;
-  role: 'student' | 'admin';
-  department?: string;
-  cgpa?: number;
-  semester?: number;
-  is_active: boolean;
-  created_at: string;
-}
+// User interface is now imported from @/types
 
 interface AuthContextType {
   user: User | null;
@@ -19,7 +11,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<User>;
   register: (userData: RegisterRequest) => Promise<User>;
   logout: () => Promise<void>;
-  updateProfile: (updates: any) => Promise<User>;
+  updateProfile: (updates: { full_name?: string; department?: string; cgpa?: number; semester?: number }) => Promise<User>;
   changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
   isAuthenticated: boolean;
   isAdmin: boolean;
@@ -67,11 +59,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       localStorage.setItem('user', JSON.stringify(userData));
       
       return userData as User;
-    } catch (error: any) {
+    } catch (error) {
       console.error('Login error:', error);
-      // Ensure error has a message property
-      const errorMessage = error?.message || 'Login failed. Please try again.';
-      throw { message: errorMessage };
+      const apiError = error as ApiError;
+      const errorMessage = apiError.message || 'Login failed. Please try again.';
+      throw { message: errorMessage } as ApiError;
     } finally {
       setIsLoading(false);
     }
@@ -91,11 +83,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       localStorage.setItem('user', JSON.stringify(newUser));
       
       return newUser as User;
-    } catch (error: any) {
+    } catch (error) {
       console.error('Registration error:', error);
-      // Ensure error has a message property
-      const errorMessage = error?.message || 'Registration failed. Please try again.';
-      throw { message: errorMessage };
+      const apiError = error as ApiError;
+      const errorMessage = apiError.message || 'Registration failed. Please try again.';
+      throw { message: errorMessage } as ApiError;
     } finally {
       setIsLoading(false);
     }
@@ -116,7 +108,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const updateProfile = async (updates: any): Promise<User> => {
+  const updateProfile = async (updates: { full_name?: string; department?: string; cgpa?: number; semester?: number }): Promise<User> => {
     try {
       setIsLoading(true);
       const response = await authService.updateProfile(updates);
@@ -127,7 +119,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return updatedUser as User;
     } catch (error) {
       console.error('Update profile error:', error);
-      throw error;
+      throw error as ApiError;
     } finally {
       setIsLoading(false);
     }

--- a/smart-campus-frontend/src/lib/axios.ts
+++ b/smart-campus-frontend/src/lib/axios.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { ApiError } from '@/types';
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
@@ -20,27 +21,31 @@ api.interceptors.request.use((config) => {
 // Response interceptor for better error handling
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  (error: AxiosError<ApiError>) => {
     // Handle network errors
     if (error.code === 'ECONNREFUSED' || error.code === 'ERR_NETWORK') {
       console.error('Network error:', error.message);
-      return Promise.reject({
+      const networkError: ApiError = {
         message: 'Cannot connect to server. Please ensure the backend server is running.',
         code: error.code,
-      });
+      };
+      return Promise.reject(networkError);
     }
     
     // Handle timeout errors
     if (error.code === 'ECONNABORTED') {
-      return Promise.reject({
+      const timeoutError: ApiError = {
         message: 'Request timeout. Please try again.',
         code: error.code,
-      });
+      };
+      return Promise.reject(timeoutError);
     }
     
-    // Pass through other errors
-    return Promise.reject(error);
+    // Pass through other errors, structured by types
+    return Promise.reject(error.response?.data || { message: error.message });
   }
 );
+
+export default api;
 
 export default api;

--- a/smart-campus-frontend/src/services/authService.ts
+++ b/smart-campus-frontend/src/services/authService.ts
@@ -1,5 +1,7 @@
 import { api } from '@/lib/axios';
 import { withServiceError } from './serviceUtils';
+import { User, ApiResponse, ApiError, UserRole } from '@/types';
+import { AxiosError } from 'axios';
 
 export interface LoginRequest {
   email: string;
@@ -17,23 +19,16 @@ export interface RegisterRequest {
   cgpa?: number;
 }
 
-export interface AuthResponse {
-  success: boolean;
-  message: string;
-  data: {
-    user: {
-      id: number;
-      full_name: string;
-      email: string;
-      role: string;
-      department?: string;
-      cgpa?: number;
-      semester?: number;
-      is_active: boolean;
-      created_at: string;
-    };
-    token: string;
-  };
+export type AuthResponse = ApiResponse<{
+  user: User;
+  token: string;
+}>;
+
+export interface ProfileUpdate {
+  full_name?: string;
+  department?: string;
+  cgpa?: number;
+  semester?: number;
 }
 
 export const authService = {
@@ -43,7 +38,7 @@ export const authService = {
    */
   login: async (email: string, password: string): Promise<AuthResponse> => {
     try {
-      const { data } = await api.post('/auth/login', { email, password });
+      const { data } = await api.post<AuthResponse>('/auth/login', { email, password });
       
       // Store token in localStorage
       if (data.data.token) {
@@ -52,22 +47,23 @@ export const authService = {
       }
       
       return data;
-    } catch (error: any) {
+    } catch (error) {
+      const axiosError = error as AxiosError<ApiError>;
       // Extract error message from various possible error formats
       const errorMessage = 
-        error.response?.data?.message || 
-        error.response?.data?.error || 
-        error.message || 
+        axiosError.response?.data?.message || 
+        axiosError.response?.data?.error || 
+        axiosError.message || 
         'Login failed. Please check your credentials and try again.';
       
       // Check if backend is reachable
-      if (error.code === 'ECONNREFUSED' || error.code === 'ERR_NETWORK') {
+      if (axiosError.code === 'ECONNREFUSED' || axiosError.code === 'ERR_NETWORK') {
         throw { 
           message: 'Cannot connect to server. Please ensure the backend server is running.' 
-        };
+        } as ApiError;
       }
       
-      throw { message: errorMessage };
+      throw { message: errorMessage } as ApiError;
     }
   },
 
@@ -82,22 +78,22 @@ export const authService = {
       // Validate role-specific fields
       if (userData.role === 'student') {
         if (!userData.cgpa || !userData.semester) {
-          throw new Error('CGPA and Semester are required for students');
+          throw { message: 'CGPA and Semester are required for students' } as ApiError;
         }
         if (userData.cgpa < 0 || userData.cgpa > 10) {
-          throw new Error('CGPA must be between 0 and 10');
+          throw { message: 'CGPA must be between 0 and 10' } as ApiError;
         }
         if (userData.semester < 1 || userData.semester > 8) {
-          throw new Error('Semester must be between 1 and 8');
+          throw { message: 'Semester must be between 1 and 8' } as ApiError;
         }
       }
 
-      const payload: any = {
+      const payload: Partial<RegisterRequest> = {
         full_name: userData.full_name,
         email: userData.email,
         password: userData.password,
         role: userData.role,
-        department: userData.department || null
+        department: userData.department || undefined
       };
 
       // Only add cgpa and semester for students
@@ -106,7 +102,7 @@ export const authService = {
         payload.cgpa = userData.cgpa;
       }
 
-      const { data } = await api.post('/auth/register', payload);
+      const { data } = await api.post<AuthResponse>('/auth/register', payload);
       
       // Store token in localStorage
       if (data.data.token) {
@@ -115,30 +111,37 @@ export const authService = {
       }
       
       return data;
-    } catch (error: any) {
+    } catch (error) {
+      const axiosError = error as AxiosError<ApiError>;
+      
+      // If it's the specific validation errors we just threw
+      if (!(axiosError instanceof AxiosError) && (axiosError as ApiError).message) {
+        throw axiosError;
+      }
+
       // Extract error message from various possible error formats
       const errorMessage = 
-        error.response?.data?.message || 
-        error.response?.data?.error || 
-        error.message || 
+        axiosError.response?.data?.message || 
+        axiosError.response?.data?.error || 
+        axiosError.message || 
         'Registration failed. Please check your information and try again.';
       
       // Check if backend is reachable
-      if (error.code === 'ECONNREFUSED' || error.code === 'ERR_NETWORK') {
+      if (axiosError.code === 'ECONNREFUSED' || axiosError.code === 'ERR_NETWORK') {
         throw { 
           message: 'Cannot connect to server. Please ensure the backend server is running.' 
-        };
+        } as ApiError;
       }
       
       // Handle validation errors
-      if (error.response?.status === 400) {
-        const validationErrors = error.response?.data?.errors;
+      if (axiosError.response?.status === 400) {
+        const validationErrors = axiosError.response?.data?.errors;
         if (validationErrors && Array.isArray(validationErrors)) {
-          throw { message: validationErrors.join(', ') };
+          throw { message: validationErrors.join(', ') } as ApiError;
         }
       }
       
-      throw { message: errorMessage };
+      throw { message: errorMessage } as ApiError;
     }
   },
 
@@ -146,11 +149,11 @@ export const authService = {
    * Get current authenticated user profile
    * Protected route - requires valid JWT token
    */
-  getProfile: async (): Promise<{ success: boolean; data: { user: any } }> => {
+  getProfile: async (): Promise<ApiResponse<{ user: User }>> => {
     try {
-      const { data } = await api.get('/auth/profile');
+      const { data } = await api.get<ApiResponse<{ user: User }>>('/auth/profile');
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to fetch profile');
     }
   },
@@ -160,9 +163,9 @@ export const authService = {
    * Can update: full_name, department, cgpa (for students), semester (for students)
    * Protected route - requires valid JWT token
    */
-  updateProfile: async (updates: any): Promise<{ success: boolean; message: string; data: { user: any } }> => {
+  updateProfile: async (updates: ProfileUpdate): Promise<ApiResponse<{ user: User }>> => {
     try {
-      const { data } = await api.put('/auth/profile', updates);
+      const { data } = await api.put<ApiResponse<{ user: User }>>('/auth/profile', updates);
       
       // Update localStorage user
       const currentUser = JSON.parse(localStorage.getItem('user') || '{}');
@@ -170,7 +173,7 @@ export const authService = {
       localStorage.setItem('user', JSON.stringify(updatedUser));
       
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to update profile');
     }
   },
@@ -180,14 +183,14 @@ export const authService = {
    * Requires old and new password
    * Protected route - requires valid JWT token
    */
-  changePassword: async (oldPassword: string, newPassword: string): Promise<{ success: boolean; message: string }> => {
+  changePassword: async (oldPassword: string, newPassword: string): Promise<ApiResponse<null>> => {
     try {
-      const { data } = await api.post('/auth/change-password', {
+      const { data } = await api.post<ApiResponse<null>>('/auth/change-password', {
         oldPassword,
         newPassword
       });
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to change password');
     }
   },
@@ -204,7 +207,7 @@ export const authService = {
       // Clear localStorage
       localStorage.removeItem('authToken');
       localStorage.removeItem('user');
-    } catch (error: any) {
+    } catch (error) {
       // Still clear local storage even if logout fails
       localStorage.removeItem('authToken');
       localStorage.removeItem('user');
@@ -215,9 +218,9 @@ export const authService = {
   /**
    * Get stored user from localStorage
    */
-  getStoredUser: () => {
+  getStoredUser: (): User | null => {
     const user = localStorage.getItem('user');
-    return user ? JSON.parse(user) : null;
+    return user ? JSON.parse(user) as User : null;
   },
 
   /**

--- a/smart-campus-frontend/src/services/electiveService.ts
+++ b/smart-campus-frontend/src/services/electiveService.ts
@@ -1,16 +1,6 @@
 import { api } from '@/lib/axios';
 import { asApiData, getPayload, getPayloadArray, withServiceError } from './serviceUtils';
-
-export interface Elective {
-  id: number;
-  subject_name: string;
-  description: string;
-  max_students: number;
-  department: string;
-  semester: number;
-  created_at: string;
-  updated_at: string;
-}
+import { Elective, ApiResponse } from '@/types';
 
 export interface StudentChoice {
   preference_rank: number;
@@ -51,7 +41,7 @@ export const electiveService = {
       
       const data = asApiData(await api.get(`/electives${params.toString() ? `?${params.toString()}` : ''}`));
       return getPayloadArray<Elective>(data, 'electives');
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to fetch electives');
     }
   },
@@ -63,7 +53,7 @@ export const electiveService = {
     try {
       const data = asApiData(await api.get(`/electives/${id}`));
       return getPayload<Elective>(data, 'elective') as Elective;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to fetch elective');
     }
   },
@@ -81,7 +71,7 @@ export const electiveService = {
     try {
       const data = asApiData(await api.post('/electives', electiveData));
       return getPayload<Elective>(data, 'elective') as Elective;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to create elective');
     }
   },
@@ -93,7 +83,7 @@ export const electiveService = {
     try {
       const data = asApiData(await api.put(`/electives/${id}`, electiveData));
       return getPayload<Elective>(data, 'elective') as Elective;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to update elective');
     }
   },
@@ -104,7 +94,7 @@ export const electiveService = {
   delete: async (id: number): Promise<void> => {
     try {
       await api.delete(`/electives/${id}`);
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to delete elective');
     }
   },
@@ -116,7 +106,7 @@ export const electiveService = {
   submitChoices: async (choices: Array<{ subject_name: string; preference_rank: number }>): Promise<void> => {
     try {
       await api.post('/electives/choices', { choices });
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to submit elective choices');
     }
   },
@@ -128,7 +118,7 @@ export const electiveService = {
     try {
       const data = asApiData(await api.get('/electives/my/choices'));
       return getPayloadArray<StudentChoice>(data, 'choices');
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to fetch your choices');
     }
   },
@@ -140,7 +130,7 @@ export const electiveService = {
     try {
       const data = asApiData(await api.get('/electives/my/allocation'));
       return (getPayload<StudentAllocation | null>(data, 'allocation') ?? null) as StudentAllocation | null;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to fetch your allocation');
     }
   },

--- a/smart-campus-frontend/src/services/eventService.ts
+++ b/smart-campus-frontend/src/services/eventService.ts
@@ -1,22 +1,6 @@
 import { api } from '@/lib/axios';
 import { asApiData, withServiceError } from './serviceUtils';
-
-export interface Event {
-  id: number;
-  title: string;
-  description: string;
-  location: string;
-  start_time: string;
-  end_time: string;
-  club_id?: number;
-  club_name?: string;
-  club_description?: string;
-  target_department?: string;
-  is_featured: boolean;
-  tags?: string[];
-  created_at: string;
-  updated_at: string;
-}
+import { CampusEvent as Event, ApiResponse } from '@/types';
 
 export interface SavedEvent extends Event {
   saved_at: string;
@@ -91,7 +75,7 @@ export const eventsService = {
       const query = params.toString() ? `?${params.toString()}` : '';
       const data = asApiData(await api.get(`/events${query}`));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to load events');
     }
   },
@@ -99,11 +83,11 @@ export const eventsService = {
   /**
    * Get single event by ID with club and events details
    */
-  getById: async (eventId: string | number): Promise<{ data: { event: Event } }> => {
+  getById: async (eventId: string | number): Promise<ApiResponse<{ event: Event }>> => {
     try {
       const data = asApiData(await api.get(`/events/${eventId}`));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to load event');
     }
   },
@@ -111,7 +95,7 @@ export const eventsService = {
   /**
    * Create a new event (Admin only)
    */
-  create: async (eventData: CreateEventData): Promise<{ data: { event: Event } }> => {
+  create: async (eventData: CreateEventData): Promise<ApiResponse<{ event: Event }>> => {
     try {
       const payload = {
         ...eventData,
@@ -121,7 +105,7 @@ export const eventsService = {
       };
       const data = asApiData(await api.post('/events', payload));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to create event');
     }
   },
@@ -132,7 +116,7 @@ export const eventsService = {
   update: async (
     id: string | number,
     eventData: Partial<CreateEventData>
-  ): Promise<{ data: { event: Event } }> => {
+  ): Promise<ApiResponse<{ event: Event }>> => {
     try {
       const payload = {
         ...eventData,
@@ -142,7 +126,7 @@ export const eventsService = {
       };
       const data = asApiData(await api.put(`/events/${id}`, payload));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to update event');
     }
   },
@@ -154,7 +138,7 @@ export const eventsService = {
     try {
       const data = asApiData(await api.delete(`/events/${id}`));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to delete event');
     }
   },
@@ -166,7 +150,7 @@ export const eventsService = {
     try {
       const data = asApiData(await api.post(`/events/${eventId}/save`));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to save event');
     }
   },
@@ -178,7 +162,7 @@ export const eventsService = {
     try {
       const data = asApiData(await api.delete(`/events/${eventId}/save`));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to unsave event');
     }
   },
@@ -190,7 +174,7 @@ export const eventsService = {
     try {
       const data = asApiData(await api.get('/events/saved/my-events'));
       return data;
-    } catch (error: any) {
+    } catch (error) {
       withServiceError(error, 'Failed to load saved events');
     }
   },

--- a/smart-campus-frontend/src/services/serviceUtils.ts
+++ b/smart-campus-frontend/src/services/serviceUtils.ts
@@ -1,13 +1,16 @@
-export const getPayload = <T = unknown>(data: any, key: string): T | undefined => {
-  return data?.data?.[key] as T | undefined;
+import { ApiResponse, ApiError } from '@/types';
+
+export const getPayload = <T = unknown>(data: ApiResponse<any>, key: string): T | undefined => {
+  return (data?.data as any)?.[key] as T | undefined;
 };
 
-export const getPayloadArray = <T = unknown>(data: any, key: string): T[] => {
-  return (data?.data?.[key] as T[]) || [];
+export const getPayloadArray = <T = unknown>(data: ApiResponse<any>, key: string): T[] => {
+  return ((data?.data as any)?.[key] as T[]) || [];
 };
 
-export const withServiceError = (error: any, fallbackMessage: string) => {
-  throw error?.response?.data || { message: fallbackMessage };
+export const withServiceError = (error: any, fallbackMessage: string): never => {
+  const apiError = error?.response?.data as ApiError | undefined;
+  throw apiError || { message: fallbackMessage };
 };
 
 export const asApiData = <T = unknown>(response: { data: T }): T => response.data;

--- a/smart-campus-frontend/src/services/userService.ts
+++ b/smart-campus-frontend/src/services/userService.ts
@@ -1,25 +1,29 @@
 import { api } from '@/lib/axios';
 import { getPayload, getPayloadArray } from './serviceUtils';
+import { User, ApiResponse } from '@/types';
 
-const normalizeUser = (user: any) => ({
+// We might want a type for user forms/creation that differs slightly from the base User
+type UserFormData = Partial<User> & { password?: string };
+
+const normalizeUser = (user: any): User & { name: string } => ({
   ...user,
   name: user.full_name,
 });
 
 export const userService = {
-  getAll: async () => {
-    const { data } = await api.get('/users');
-    const users = getPayloadArray<any>(data, 'users');
+  getAll: async (): Promise<Array<User & { name: string }>> => {
+    const { data } = await api.get<ApiResponse<{ users: User[] }>>('/users');
+    const users = getPayloadArray<User>(data.data as any, 'users');
     return users.map(normalizeUser);
   },
 
-  create: async (userData: any) => {
-    const payload: any = {
+  create: async (userData: UserFormData): Promise<User & { name: string }> => {
+    const payload: UserFormData = {
       full_name: userData.full_name,
       email: userData.email,
       password: userData.password,
       role: userData.role,
-      department: userData.department || undefined,
+      department: userData.department,
     };
 
     if (userData.role === 'student') {
@@ -27,16 +31,16 @@ export const userService = {
       payload.semester = userData.semester;
     }
 
-    const { data } = await api.post('/auth/register', payload);
-    return normalizeUser(getPayload<any>(data, 'user'));
+    const { data } = await api.post<ApiResponse<{ user: User }>>('/auth/register', payload);
+    return normalizeUser(getPayload<User>(data.data as any, 'user'));
   },
 
-  update: async (id: string, userData: any) => {
-    const payload: any = {
+  update: async (id: string | number, userData: UserFormData): Promise<User & { name: string }> => {
+    const payload: UserFormData = {
       full_name: userData.full_name,
       email: userData.email,
       role: userData.role,
-      department: userData.department || null,
+      department: userData.department,
       is_active: userData.is_active,
     };
 
@@ -44,15 +48,15 @@ export const userService = {
       payload.cgpa = userData.cgpa;
       payload.semester = userData.semester;
     } else {
-      payload.cgpa = null;
-      payload.semester = null;
+      payload.cgpa = undefined;
+      payload.semester = undefined;
     }
 
-    const { data } = await api.put(`/users/${id}`, payload);
-    return normalizeUser(getPayload<any>(data, 'user'));
+    const { data } = await api.put<ApiResponse<{ user: User }>>(`/users/${id}`, payload);
+    return normalizeUser(getPayload<User>(data.data as any, 'user'));
   },
 
-  delete: async (id: string) => {
+  delete: async (id: string | number): Promise<void> => {
     await api.delete(`/users/${id}`);
   },
 };

--- a/smart-campus-frontend/src/types/index.ts
+++ b/smart-campus-frontend/src/types/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Common API response structure
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+/**
+ * Standard API error shape
+ */
+export interface ApiError {
+  message: string;
+  code?: string;
+  errors?: string[];
+  success?: boolean;
+}
+
+/**
+ * User Role type
+ */
+export type UserRole = 'student' | 'admin' | 'faculty';
+
+/**
+ * User interface
+ */
+export interface User {
+  id: number;
+  full_name: string;
+  email: string;
+  role: UserRole;
+  department?: string;
+  cgpa?: number;
+  semester?: number;
+  is_active: boolean;
+  created_at: string;
+}
+
+/**
+ * Event interface
+ */
+export interface CampusEvent {
+  id: number;
+  title: string;
+  description: string;
+  location: string;
+  start_time: string;
+  end_time: string;
+  club_id?: number;
+  club_name?: string;
+  target_department?: string;
+  is_featured: boolean;
+  tags?: string[];
+  image_url?: string;
+}
+
+/**
+ * Elective interface
+ */
+export interface Elective {
+  id: number;
+  subject_name: string;
+  description: string;
+  max_students: number;
+  department: string;
+  semester: number;
+  current_students?: number;
+  teacher_name?: string;
+}
+
+/**
+ * Club interface
+ */
+export interface Club {
+  id: number;
+  name: string;
+  description: string;
+  contact_email: string;
+  category: string;
+  image_url?: string;
+}

--- a/smart-campus-frontend/vite.config.ts.timestamp-1776796443756-1c89f8cf6e488.mjs
+++ b/smart-campus-frontend/vite.config.ts.timestamp-1776796443756-1c89f8cf6e488.mjs
@@ -1,0 +1,70 @@
+// vite.config.ts
+import { defineConfig } from "file:///C:/Users/hp/smart-campus-utility-hub/smart-campus-frontend/node_modules/vite/dist/node/index.js";
+import react from "file:///C:/Users/hp/smart-campus-utility-hub/smart-campus-frontend/node_modules/@vitejs/plugin-react-swc/index.js";
+import path from "path";
+import { componentTagger } from "file:///C:/Users/hp/smart-campus-utility-hub/smart-campus-frontend/node_modules/lovable-tagger/dist/index.js";
+var __vite_injected_original_dirname = "C:\\Users\\hp\\smart-campus-utility-hub\\smart-campus-frontend";
+var vite_config_default = defineConfig(({ mode }) => ({
+  server: {
+    host: "::",
+    port: 8080
+  },
+  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+  resolve: {
+    alias: {
+      "@": path.resolve(__vite_injected_original_dirname, "./src")
+    }
+  },
+  esbuild: {
+    // Drop console and debugger in production
+    drop: mode === "production" ? ["console", "debugger"] : [],
+    // Legal comments handling
+    legalComments: "none",
+    // Minify identifiers in production
+    minifyIdentifiers: mode === "production",
+    // Minify syntax in production
+    minifySyntax: mode === "production",
+    // Minify whitespace in production
+    minifyWhitespace: mode === "production",
+    // Target modern browsers
+    target: "es2020"
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "es2020"
+    }
+  },
+  build: {
+    target: "es2020",
+    minify: "esbuild",
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("react") || id.includes("react-dom") || id.includes("react-router")) {
+            return "react-core";
+          }
+          if (id.includes("@tanstack") || id.includes("axios")) {
+            return "data-layer";
+          }
+          if (id.includes("three") || id.includes("@react-three") || id.includes("@react-spring") || id.includes("maath")) {
+            return "3d-stack";
+          }
+          if (id.includes("framer-motion")) {
+            return "motion";
+          }
+          if (id.includes("@radix-ui") || id.includes("lucide-react") || id.includes("class-variance-authority") || id.includes("tailwind-merge")) {
+            return "ui-kit";
+          }
+          return "vendor";
+        }
+      }
+    },
+    // Keep warning strict enough to catch regressions early
+    chunkSizeWarningLimit: 700
+  }
+}));
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCJDOlxcXFxVc2Vyc1xcXFxocFxcXFxzbWFydC1jYW1wdXMtdXRpbGl0eS1odWJcXFxcc21hcnQtY2FtcHVzLWZyb250ZW5kXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ZpbGVuYW1lID0gXCJDOlxcXFxVc2Vyc1xcXFxocFxcXFxzbWFydC1jYW1wdXMtdXRpbGl0eS1odWJcXFxcc21hcnQtY2FtcHVzLWZyb250ZW5kXFxcXHZpdGUuY29uZmlnLnRzXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ltcG9ydF9tZXRhX3VybCA9IFwiZmlsZTovLy9DOi9Vc2Vycy9ocC9zbWFydC1jYW1wdXMtdXRpbGl0eS1odWIvc21hcnQtY2FtcHVzLWZyb250ZW5kL3ZpdGUuY29uZmlnLnRzXCI7aW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSBcInZpdGVcIjtcclxuaW1wb3J0IHJlYWN0IGZyb20gXCJAdml0ZWpzL3BsdWdpbi1yZWFjdC1zd2NcIjtcclxuaW1wb3J0IHBhdGggZnJvbSBcInBhdGhcIjtcclxuaW1wb3J0IHsgY29tcG9uZW50VGFnZ2VyIH0gZnJvbSBcImxvdmFibGUtdGFnZ2VyXCI7XHJcblxyXG4vLyBodHRwczovL3ZpdGVqcy5kZXYvY29uZmlnL1xyXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKHsgbW9kZSB9KSA9PiAoe1xyXG4gIHNlcnZlcjoge1xyXG4gICAgaG9zdDogXCI6OlwiLFxyXG4gICAgcG9ydDogODA4MCxcclxuICB9LFxyXG4gIHBsdWdpbnM6IFtyZWFjdCgpLCBtb2RlID09PSBcImRldmVsb3BtZW50XCIgJiYgY29tcG9uZW50VGFnZ2VyKCldLmZpbHRlcihCb29sZWFuKSxcclxuICByZXNvbHZlOiB7XHJcbiAgICBhbGlhczoge1xyXG4gICAgICBcIkBcIjogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgXCIuL3NyY1wiKSxcclxuICAgIH0sXHJcbiAgfSxcclxuICBlc2J1aWxkOiB7XHJcbiAgICAvLyBEcm9wIGNvbnNvbGUgYW5kIGRlYnVnZ2VyIGluIHByb2R1Y3Rpb25cclxuICAgIGRyb3A6IG1vZGUgPT09IFwicHJvZHVjdGlvblwiID8gW1wiY29uc29sZVwiLCBcImRlYnVnZ2VyXCJdIDogW10sXHJcbiAgICAvLyBMZWdhbCBjb21tZW50cyBoYW5kbGluZ1xyXG4gICAgbGVnYWxDb21tZW50czogXCJub25lXCIsXHJcbiAgICAvLyBNaW5pZnkgaWRlbnRpZmllcnMgaW4gcHJvZHVjdGlvblxyXG4gICAgbWluaWZ5SWRlbnRpZmllcnM6IG1vZGUgPT09IFwicHJvZHVjdGlvblwiLFxyXG4gICAgLy8gTWluaWZ5IHN5bnRheCBpbiBwcm9kdWN0aW9uXHJcbiAgICBtaW5pZnlTeW50YXg6IG1vZGUgPT09IFwicHJvZHVjdGlvblwiLFxyXG4gICAgLy8gTWluaWZ5IHdoaXRlc3BhY2UgaW4gcHJvZHVjdGlvblxyXG4gICAgbWluaWZ5V2hpdGVzcGFjZTogbW9kZSA9PT0gXCJwcm9kdWN0aW9uXCIsXHJcbiAgICAvLyBUYXJnZXQgbW9kZXJuIGJyb3dzZXJzXHJcbiAgICB0YXJnZXQ6IFwiZXMyMDIwXCIsXHJcbiAgfSxcclxuICBvcHRpbWl6ZURlcHM6IHtcclxuICAgIGVzYnVpbGRPcHRpb25zOiB7XHJcbiAgICAgIHRhcmdldDogXCJlczIwMjBcIixcclxuICAgIH0sXHJcbiAgfSxcclxuICBidWlsZDoge1xyXG4gICAgdGFyZ2V0OiBcImVzMjAyMFwiLFxyXG4gICAgbWluaWZ5OiBcImVzYnVpbGRcIixcclxuICAgIHJvbGx1cE9wdGlvbnM6IHtcclxuICAgICAgb3V0cHV0OiB7XHJcbiAgICAgICAgbWFudWFsQ2h1bmtzKGlkKSB7XHJcbiAgICAgICAgICBpZiAoIWlkLmluY2x1ZGVzKFwibm9kZV9tb2R1bGVzXCIpKSByZXR1cm47XHJcbiAgICAgICAgICBpZiAoaWQuaW5jbHVkZXMoXCJyZWFjdFwiKSB8fCBpZC5pbmNsdWRlcyhcInJlYWN0LWRvbVwiKSB8fCBpZC5pbmNsdWRlcyhcInJlYWN0LXJvdXRlclwiKSkge1xyXG4gICAgICAgICAgICByZXR1cm4gXCJyZWFjdC1jb3JlXCI7XHJcbiAgICAgICAgICB9XHJcbiAgICAgICAgICBpZiAoaWQuaW5jbHVkZXMoXCJAdGFuc3RhY2tcIikgfHwgaWQuaW5jbHVkZXMoXCJheGlvc1wiKSkge1xyXG4gICAgICAgICAgICByZXR1cm4gXCJkYXRhLWxheWVyXCI7XHJcbiAgICAgICAgICB9XHJcbiAgICAgICAgICBpZiAoaWQuaW5jbHVkZXMoXCJ0aHJlZVwiKSB8fCBpZC5pbmNsdWRlcyhcIkByZWFjdC10aHJlZVwiKSB8fCBpZC5pbmNsdWRlcyhcIkByZWFjdC1zcHJpbmdcIikgfHwgaWQuaW5jbHVkZXMoXCJtYWF0aFwiKSkge1xyXG4gICAgICAgICAgICByZXR1cm4gXCIzZC1zdGFja1wiO1xyXG4gICAgICAgICAgfVxyXG4gICAgICAgICAgaWYgKGlkLmluY2x1ZGVzKFwiZnJhbWVyLW1vdGlvblwiKSkge1xyXG4gICAgICAgICAgICByZXR1cm4gXCJtb3Rpb25cIjtcclxuICAgICAgICAgIH1cclxuICAgICAgICAgIGlmIChpZC5pbmNsdWRlcyhcIkByYWRpeC11aVwiKSB8fCBpZC5pbmNsdWRlcyhcImx1Y2lkZS1yZWFjdFwiKSB8fCBpZC5pbmNsdWRlcyhcImNsYXNzLXZhcmlhbmNlLWF1dGhvcml0eVwiKSB8fCBpZC5pbmNsdWRlcyhcInRhaWx3aW5kLW1lcmdlXCIpKSB7XHJcbiAgICAgICAgICAgIHJldHVybiBcInVpLWtpdFwiO1xyXG4gICAgICAgICAgfVxyXG4gICAgICAgICAgcmV0dXJuIFwidmVuZG9yXCI7XHJcbiAgICAgICAgfSxcclxuICAgICAgfSxcclxuICAgIH0sXHJcbiAgICAvLyBLZWVwIHdhcm5pbmcgc3RyaWN0IGVub3VnaCB0byBjYXRjaCByZWdyZXNzaW9ucyBlYXJseVxyXG4gICAgY2h1bmtTaXplV2FybmluZ0xpbWl0OiA3MDAsXHJcbiAgfSxcclxufSkpO1xyXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQTBXLFNBQVMsb0JBQW9CO0FBQ3ZZLE9BQU8sV0FBVztBQUNsQixPQUFPLFVBQVU7QUFDakIsU0FBUyx1QkFBdUI7QUFIaEMsSUFBTSxtQ0FBbUM7QUFNekMsSUFBTyxzQkFBUSxhQUFhLENBQUMsRUFBRSxLQUFLLE9BQU87QUFBQSxFQUN6QyxRQUFRO0FBQUEsSUFDTixNQUFNO0FBQUEsSUFDTixNQUFNO0FBQUEsRUFDUjtBQUFBLEVBQ0EsU0FBUyxDQUFDLE1BQU0sR0FBRyxTQUFTLGlCQUFpQixnQkFBZ0IsQ0FBQyxFQUFFLE9BQU8sT0FBTztBQUFBLEVBQzlFLFNBQVM7QUFBQSxJQUNQLE9BQU87QUFBQSxNQUNMLEtBQUssS0FBSyxRQUFRLGtDQUFXLE9BQU87QUFBQSxJQUN0QztBQUFBLEVBQ0Y7QUFBQSxFQUNBLFNBQVM7QUFBQTtBQUFBLElBRVAsTUFBTSxTQUFTLGVBQWUsQ0FBQyxXQUFXLFVBQVUsSUFBSSxDQUFDO0FBQUE7QUFBQSxJQUV6RCxlQUFlO0FBQUE7QUFBQSxJQUVmLG1CQUFtQixTQUFTO0FBQUE7QUFBQSxJQUU1QixjQUFjLFNBQVM7QUFBQTtBQUFBLElBRXZCLGtCQUFrQixTQUFTO0FBQUE7QUFBQSxJQUUzQixRQUFRO0FBQUEsRUFDVjtBQUFBLEVBQ0EsY0FBYztBQUFBLElBQ1osZ0JBQWdCO0FBQUEsTUFDZCxRQUFRO0FBQUEsSUFDVjtBQUFBLEVBQ0Y7QUFBQSxFQUNBLE9BQU87QUFBQSxJQUNMLFFBQVE7QUFBQSxJQUNSLFFBQVE7QUFBQSxJQUNSLGVBQWU7QUFBQSxNQUNiLFFBQVE7QUFBQSxRQUNOLGFBQWEsSUFBSTtBQUNmLGNBQUksQ0FBQyxHQUFHLFNBQVMsY0FBYyxFQUFHO0FBQ2xDLGNBQUksR0FBRyxTQUFTLE9BQU8sS0FBSyxHQUFHLFNBQVMsV0FBVyxLQUFLLEdBQUcsU0FBUyxjQUFjLEdBQUc7QUFDbkYsbUJBQU87QUFBQSxVQUNUO0FBQ0EsY0FBSSxHQUFHLFNBQVMsV0FBVyxLQUFLLEdBQUcsU0FBUyxPQUFPLEdBQUc7QUFDcEQsbUJBQU87QUFBQSxVQUNUO0FBQ0EsY0FBSSxHQUFHLFNBQVMsT0FBTyxLQUFLLEdBQUcsU0FBUyxjQUFjLEtBQUssR0FBRyxTQUFTLGVBQWUsS0FBSyxHQUFHLFNBQVMsT0FBTyxHQUFHO0FBQy9HLG1CQUFPO0FBQUEsVUFDVDtBQUNBLGNBQUksR0FBRyxTQUFTLGVBQWUsR0FBRztBQUNoQyxtQkFBTztBQUFBLFVBQ1Q7QUFDQSxjQUFJLEdBQUcsU0FBUyxXQUFXLEtBQUssR0FBRyxTQUFTLGNBQWMsS0FBSyxHQUFHLFNBQVMsMEJBQTBCLEtBQUssR0FBRyxTQUFTLGdCQUFnQixHQUFHO0FBQ3ZJLG1CQUFPO0FBQUEsVUFDVDtBQUNBLGlCQUFPO0FBQUEsUUFDVDtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBQUE7QUFBQSxJQUVBLHVCQUF1QjtBQUFBLEVBQ3pCO0FBQ0YsRUFBRTsiLAogICJuYW1lcyI6IFtdCn0K


### PR DESCRIPTION
##Summary of Changes
Implemented a centralized type system to replace any usages across the frontend service layer and authentication context, significantly improving type safety and error handling.

##Technical Refactor
Centralized Types: Created src/types/index.ts defining standard interfaces for User, CampusEvent, Elective, ApiResponse, and ApiError.

Infrastructure:
Typed axios.ts interceptors to consistently return ApiError objects.
Updated serviceUtils.ts with generics for payload extraction and typed error throwing.

Auth & Context:
Refactored AuthContext.tsx to use strict user typing and typed profile updates.
Updated authService.ts methods (Login/Register/Profile) to use explicit Request/Response interfaces.

Services:
Replaced any with domain-specific types in userService, eventService, and electiveService.
Ensured all catch blocks use typed error handling rather than any casting.

Verified with npm run typecheck (0 errors found).

