### PR TITLE
fix(auth): distinguish expired vs invalid JWT errors

### DIFF
--- a/smart-campus-backend/__tests__/middleware.test.js
+++ b/smart-campus-backend/__tests__/middleware.test.js
@@ -67,6 +67,43 @@ describe('Middleware Tests', () => {
       expect(next).not.toHaveBeenCalled();
       done();
     });
+
+    test('should return 401 TOKEN_EXPIRED for an expired token', (done) => {
+      const payload = { id: 1, email: 'test@example.com', role: 'student' };
+      const expired = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: -1 });
+
+      const req = { headers: { authorization: `Bearer ${expired}` } };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockImplementation(() => {
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ success: false, code: 'TOKEN_EXPIRED' })
+          );
+          done();
+        })
+      };
+      const next = jest.fn();
+
+      verifyToken(req, res, next);
+    });
+
+    test('should return 401 TOKEN_INVALID for a tampered token', (done) => {
+      const req = { headers: { authorization: 'Bearer not-a-real-jwt' } };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockImplementation(() => {
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ success: false, code: 'TOKEN_INVALID' })
+          );
+          done();
+        })
+      };
+      const next = jest.fn();
+
+      verifyToken(req, res, next);
+    });
   });
 
   describe('Validation Middleware', () => {

--- a/smart-campus-backend/src/middleware/auth.middleware.js
+++ b/smart-campus-backend/src/middleware/auth.middleware.js
@@ -21,10 +21,26 @@ const verifyToken = (req, res, next) => {
     // Verify token
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
       if (err) {
-        logger.warn('Invalid token attempt', { error: err.message });
-        return res.status(403).json({ 
+        if (err.name === 'TokenExpiredError') {
+          logger.warn('Expired token attempt', {
+            errorName: err.name,
+            expiredAt: err.expiredAt,
+          });
+          return res.status(401).json({
+            success: false,
+            code: 'TOKEN_EXPIRED',
+            message: 'Unauthorized: Token has expired. Please sign in again.',
+          });
+        }
+
+        logger.warn('Invalid token attempt', {
+          errorName: err.name,
+          error: err.message,
+        });
+        return res.status(401).json({
           success: false,
-          message: 'Forbidden: Invalid or expired token.' 
+          code: 'TOKEN_INVALID',
+          message: 'Unauthorized: Invalid token.',
         });
       }
 


### PR DESCRIPTION
## Summary
Distinguish expired from invalid JWT errors in `verifyToken` so clients can route "refresh" vs. "force re-login" without parsing error strings. Covered by two new middleware tests.

## Why this matters
Issue #49 pointed at `smart-campus-backend/src/middleware/auth.middleware.js` - the `verifyToken` jwt.verify callback returned the same 403 with "Forbidden: Invalid or expired token." for every failure mode. A frontend that wants to silently refresh an expired session has no way to tell that from a tampered token, and the single log line "Invalid token attempt" lumps both into the same bucket for maintainers too.

`jsonwebtoken` already distinguishes the two cases via `err.name`: `TokenExpiredError` vs. `JsonWebTokenError`. This PR just branches on that.

## Changes
- `smart-campus-backend/src/middleware/auth.middleware.js`
  - `TokenExpiredError` -> `401 TOKEN_EXPIRED` with a refresh-oriented message; log payload includes `errorName` + `expiredAt`
  - Anything else -> `401 TOKEN_INVALID`; log payload includes `errorName` + `error.message` (no raw token)
  - Both responses standardize on `401` (the status the issue asks be consistent) and add a machine-readable `code` field
- `smart-campus-backend/__tests__/middleware.test.js`
  - New "should return 401 TOKEN_EXPIRED for an expired token" using `expiresIn: -1`
  - New "should return 401 TOKEN_INVALID for a tampered token" using a garbage Bearer

## Testing
```
$ npx jest __tests__/middleware.test.js
PASS __tests__/middleware.test.js
  Authentication Middleware
    ✓ should generate a valid JWT token
    ✓ should verify valid token in request
    ✓ should reject request without token
    ✓ should return 401 TOKEN_EXPIRED for an expired token
    ✓ should return 401 TOKEN_INVALID for a tampered token
  Validation Middleware (passing)
Tests: 7 passed
```

Fixes #49

This contribution was developed with AI assistance (Claude Code).
