### PR TITLE
feat: add strict rate limiting for authentication endpoints

### DIFF
--- a/smart-campus-backend/.env.example
+++ b/smart-campus-backend/.env.example
@@ -43,6 +43,8 @@ CORS_ORIGINS=https://your-frontend-domain.com
 # -----------------------------------------------
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+AUTH_RATE_LIMIT_WINDOW_MS=900000
+AUTH_RATE_LIMIT_MAX_REQUESTS=5
 
 # -----------------------------------------------
 # Logging

--- a/smart-campus-backend/src/app.js
+++ b/smart-campus-backend/src/app.js
@@ -7,6 +7,7 @@ require('dotenv').config();
 
 const { testConnection, logger, isDatabaseConnected } = require('./config/db');
 const { errorHandler, notFoundHandler } = require('./middleware/errorHandler');
+const { apiLimiter } = require('./middleware/rateLimiter.middleware');
 
 // Import routes
 const userRoutes = require('./components/users/user.routes');
@@ -47,17 +48,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // Rate limiting
-const limiter = rateLimit({
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
-  max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100,
-  message: {
-    success: false,
-    error: 'Too many requests from this IP, please try again later.',
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-app.use('/api/', limiter);
+app.use('/api/', apiLimiter);
 
 // Compression middleware
 app.use(compression());

--- a/smart-campus-backend/src/components/users/user.routes.js
+++ b/smart-campus-backend/src/components/users/user.routes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const userController = require('./user.controller');
 const { verifyToken, verifyAdmin } = require('../../middleware/auth.middleware');
 const { validate, validationSchemas } = require('../../middleware/validation');
+const { authLimiter } = require('../../middleware/rateLimiter.middleware');
 
 /**
  * User Routes
@@ -12,12 +13,14 @@ const { validate, validationSchemas } = require('../../middleware/validation');
 // Public routes (no authentication required)
 router.post(
   '/register',
+  authLimiter,
   validate(validationSchemas.register),
   userController.register
 );
 
 router.post(
   '/login',
+  authLimiter,
   validate(validationSchemas.login),
   userController.login
 );

--- a/smart-campus-backend/src/middleware/rateLimiter.middleware.js
+++ b/smart-campus-backend/src/middleware/rateLimiter.middleware.js
@@ -1,0 +1,39 @@
+const rateLimit = require('express-rate-limit');
+
+/**
+ * General API Rate Limiter
+ * Applied to all /api routes by default
+ */
+const apiLimiter = rateLimit({
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
+  max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100,
+  message: {
+    success: false,
+    error: 'Too many requests from this IP, please try again later.',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Strict Auth Rate Limiter
+ * Specifically for login and register endpoints to prevent brute-force attacks
+ */
+const authLimiter = rateLimit({
+  windowMs: parseInt(process.env.AUTH_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
+  max: parseInt(process.env.AUTH_RATE_LIMIT_MAX_REQUESTS) || 5, // 5 attempts per window
+  message: {
+    success: false,
+    error: 'Too many authentication attempts. Please try again after 15 minutes.',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  // We want to limit both failed and successful attempts to prevent account enumeration 
+  // and brute-force even if they manage to get a correct password eventually
+  skipSuccessfulRequests: false, 
+});
+
+module.exports = {
+  apiLimiter,
+  authLimiter,
+};


### PR DESCRIPTION
##Summary
Implemented strict rate limiting for authentication endpoints (login and signup) to prevent brute-force attacks, alongside a refactored global API rate limiter.

##Description
This PR adds a dedicated security layer to the authentication process by introducing a tighter rate limiter specifically for sensitive endpoints.

closes issue #50 

##Key Changes:

1. Centralized Rate Limiting: Created src/middleware/rateLimiter.middleware.js to manage all rate-limiting logic in one place.
2. Strict Auth Limiter: Implemented an authLimiter that restricts users to 5 attempts per 15 minutes on the /login and /register routes.
3. User-Friendly Responses: Added a specific error message for auth throttling: "Too many authentication attempts. Please try again after 15 minutes."
4. Configurability: Thresholds are now configurable via environment variables (AUTH_RATE_LIMIT_WINDOW_MS and AUTH_RATE_LIMIT_MAX_REQUESTS) for production tuning.
5. Clean Architecture: Refactored app.js to remove inline rate-limit definitions, improving code readability.


##Testing Performed:
Verified manually that the 6th consecutive request to /api/auth/login returns a 429 Too Many Requests status with the custom error message.
Confirmed that general API routes still follow the standard global rate limit (100 requests per 15 mins).