### PR TITLE
feat: add server-side pagination & sorting to timetable listing endpoints

### DIFF
--- a/smart-campus-backend/__tests__/timetable-electives.test.js
+++ b/smart-campus-backend/__tests__/timetable-electives.test.js
@@ -41,6 +41,7 @@ describe('Timetable API Tests', () => {
           { id: '123e4567-e89b-12d3-a456-426614174001', full_name: 'Prof. Johnson', department: 'Mathematics' }
         ]
       });
+      query.mockResolvedValueOnce({ rows: [{ count: '2' }] }); // count query
 
       const response = await request(app).get('/api/timetable/teachers');
 
@@ -52,6 +53,7 @@ describe('Timetable API Tests', () => {
 
     test('should filter teachers by department', async () => {
       query.mockResolvedValueOnce({ rows: [] });
+      query.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // count query
 
       const response = await request(app)
         .get('/api/timetable/teachers')
@@ -68,6 +70,7 @@ describe('Timetable API Tests', () => {
           { id: '123e4567-e89b-12d3-a456-426614174000', subject_name: 'Data Structures', course_type: 'Theory' }
         ]
       });
+      query.mockResolvedValueOnce({ rows: [{ count: '1' }] }); // count query
 
       const response = await request(app).get('/api/timetable/subjects');
 

--- a/smart-campus-backend/__tests__/timetable-generation.test.js
+++ b/smart-campus-backend/__tests__/timetable-generation.test.js
@@ -204,6 +204,7 @@ describe('Complete Timetable Generation System Tests', () => {
   describe('3. Timetable Viewing Tests', () => {
     
     test('GET /api/timetable/teachers - List all teachers', async () => {
+      // data query
       query.mockResolvedValueOnce({
         rows: [
           {
@@ -214,6 +215,8 @@ describe('Complete Timetable Generation System Tests', () => {
           }
         ]
       });
+      // count query
+      query.mockResolvedValueOnce({ rows: [{ count: '1' }] });
 
       const response = await request(app).get('/api/timetable/teachers');
 
@@ -221,9 +224,13 @@ describe('Complete Timetable Generation System Tests', () => {
       expect(response.body.success).toBe(true);
       expect(response.body.data.teachers).toBeInstanceOf(Array);
       expect(response.body.data.count).toBe(1);
+      expect(response.body.data.total).toBe(1);
+      expect(response.body.data.page).toBe(1);
+      expect(response.body.data.limit).toBe(20);
     });
 
     test('GET /api/timetable/subjects - List all subjects', async () => {
+      // data query
       query.mockResolvedValueOnce({
         rows: [
           {
@@ -234,12 +241,15 @@ describe('Complete Timetable Generation System Tests', () => {
           }
         ]
       });
+      // count query
+      query.mockResolvedValueOnce({ rows: [{ count: '1' }] });
 
       const response = await request(app).get('/api/timetable/subjects');
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.subjects).toBeInstanceOf(Array);
+      expect(response.body.data.total).toBeDefined();
     });
 
     test('GET /api/timetable/config - Get configuration', async () => {
@@ -344,7 +354,8 @@ describe('Complete Timetable Generation System Tests', () => {
     });
 
     test('Should filter teachers by department', async () => {
-      query.mockResolvedValueOnce({ rows: [] });
+      query.mockResolvedValueOnce({ rows: [] }); // data query
+      query.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // count query
 
       const response = await request(app)
         .get('/api/timetable/teachers')
@@ -353,7 +364,7 @@ describe('Complete Timetable Generation System Tests', () => {
       expect(response.status).toBe(200);
       expect(query).toHaveBeenCalledWith(
         expect.stringContaining('department'),
-        ['Computer Science']
+        expect.arrayContaining(['Computer Science'])
       );
     });
   });
@@ -385,15 +396,18 @@ describe('Complete Timetable Generation System Tests', () => {
   describe('7. Edge Cases', () => {
     
     test('Should handle empty results gracefully', async () => {
-      // Clear all previous mocks
-      jest.clearAllMocks();
-      query.mockResolvedValueOnce({ rows: [] });
+      // Reset mock queue to clear any leftover mocks from previous tests
+      query.mockReset();
+      query.mockResolvedValueOnce({ rows: [] }); // data query
+      query.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // count query
 
       const response = await request(app).get('/api/timetable/teachers');
 
       expect(response.status).toBe(200);
       expect(response.body.data.teachers).toBeInstanceOf(Array);
       expect(response.body.data).toHaveProperty('count');
+      expect(response.body.data).toHaveProperty('total');
+      expect(response.body.data.total).toBe(0);
     });
 
     test('Should handle UUID format in routes', async () => {

--- a/smart-campus-backend/__tests__/timetable-pagination.test.js
+++ b/smart-campus-backend/__tests__/timetable-pagination.test.js
@@ -1,0 +1,350 @@
+/**
+ * Integration tests for pagination and sorting on timetable list endpoints.
+ * Covers valid combinations, invalid query params (→ 400), and boundary cases.
+ */
+
+const request = require('supertest');
+const app = require('../src/app');
+
+jest.mock('../src/config/db', () => ({
+  query: jest.fn(),
+  transaction: jest.fn((callback) => callback({ query: jest.fn() })),
+  testConnection: jest.fn().mockResolvedValue(true),
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+const { query } = require('../src/config/db');
+
+// Helper: mock a successful list response (data + count queries via Promise.all)
+const mockListResponse = (rows, total) => {
+  query.mockResolvedValueOnce({ rows });          // data query
+  query.mockResolvedValueOnce({ rows: [{ count: String(total) }] }); // count query
+};
+
+describe('Timetable Listing – Pagination and Sorting', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ─── Valid combinations ────────────────────────────────────────────────────
+
+  describe('Valid pagination parameters', () => {
+
+    test('GET /api/timetable/teachers?page=1&limit=5 returns metadata', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ page: '1', limit: '5' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.page).toBe(1);
+      expect(res.body.data.limit).toBe(5);
+      expect(res.body.data.total).toBe(0);
+      expect(res.body.data.teachers).toBeInstanceOf(Array);
+    });
+
+    test('GET /api/timetable/subjects?page=2&limit=10 returns correct page', async () => {
+      mockListResponse([], 25);
+
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ page: '2', limit: '10' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.page).toBe(2);
+      expect(res.body.data.limit).toBe(10);
+      expect(res.body.data.total).toBe(25);
+    });
+
+    test('GET /api/timetable/rooms?page=1&limit=100 (max allowed limit)', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/rooms')
+        .query({ page: '1', limit: '100' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.limit).toBe(100);
+    });
+
+    test('GET /api/timetable/groups?page=1 uses default limit', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/groups')
+        .query({ page: '1' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.limit).toBe(20);
+    });
+  });
+
+  describe('Valid sort parameters', () => {
+
+    test('GET /api/timetable/teachers?sort=full_name&order=asc', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: 'full_name', order: 'asc' });
+
+      expect(res.status).toBe(200);
+      // Verify the SQL was called with the sort column
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('full_name'),
+        expect.any(Array)
+      );
+    });
+
+    test('GET /api/timetable/teachers?sort=department&order=desc', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: 'department', order: 'desc' });
+
+      expect(res.status).toBe(200);
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('DESC'),
+        expect.any(Array)
+      );
+    });
+
+    test('GET /api/timetable/subjects?sort=subject_name&order=asc', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ sort: 'subject_name', order: 'asc' });
+
+      expect(res.status).toBe(200);
+    });
+
+    test('GET /api/timetable/subjects?sort=semester', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ sort: 'semester' });
+
+      expect(res.status).toBe(200);
+    });
+
+    test('GET /api/timetable/rooms?sort=capacity&order=desc', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/rooms')
+        .query({ sort: 'capacity', order: 'desc' });
+
+      expect(res.status).toBe(200);
+    });
+
+    test('GET /api/timetable/groups?sort=group_name', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/groups')
+        .query({ sort: 'group_name' });
+
+      expect(res.status).toBe(200);
+    });
+
+    test('GET /api/timetable/teachers?sort=created_at&order=desc', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: 'created_at', order: 'desc' });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ─── Invalid combinations → 400 ───────────────────────────────────────────
+
+  describe('Invalid pagination parameters → 400', () => {
+
+    test('Non-numeric page → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ page: 'abc' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Non-numeric limit → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ limit: 'ten' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('page=0 → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ page: '0' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('page=-1 → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/rooms')
+        .query({ page: '-1' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('limit=0 → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/groups')
+        .query({ limit: '0' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('limit exceeding max (101) → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ limit: '101' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Invalid sort parameters → 400', () => {
+
+    test('Unknown sort field for teachers → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: 'password' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('SQL injection attempt in sort → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: '1; DROP TABLE teachers; --' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Unknown sort field for subjects → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ sort: 'nonexistent_column' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Unknown sort field for rooms → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/rooms')
+        .query({ sort: 'id' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Unknown sort field for groups → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/groups')
+        .query({ sort: 'strength' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Invalid order value → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ sort: 'full_name', order: 'sideways' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Invalid order value "random" → 400', async () => {
+      const res = await request(app)
+        .get('/api/timetable/subjects')
+        .query({ order: 'random' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ─── Boundary cases ────────────────────────────────────────────────────────
+
+  describe('Boundary cases', () => {
+
+    test('Page beyond total returns empty array with correct metadata', async () => {
+      mockListResponse([], 5); // only 5 total records
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ page: '999', limit: '10' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.teachers).toEqual([]);
+      expect(res.body.data.total).toBe(5);
+      expect(res.body.data.page).toBe(999);
+      expect(res.body.data.count).toBe(0);
+    });
+
+    test('Page 1 with large limit returns all items and correct count', async () => {
+      const rows = [{ id: '1', full_name: 'Alice' }, { id: '2', full_name: 'Bob' }];
+      mockListResponse(rows, 2);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ page: '1', limit: '100' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.teachers).toHaveLength(2);
+      expect(res.body.data.total).toBe(2);
+      expect(res.body.data.count).toBe(2);
+    });
+
+    test('Combined filter + pagination + sort', async () => {
+      mockListResponse([], 0);
+
+      const res = await request(app)
+        .get('/api/timetable/teachers')
+        .query({ department: 'Computer Science', page: '1', limit: '5', sort: 'full_name', order: 'desc' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.page).toBe(1);
+      expect(res.body.data.limit).toBe(5);
+    });
+
+    test('page=1&limit=20 (defaults) returns valid structure for all list endpoints', async () => {
+      const endpoints = [
+        { path: '/api/timetable/teachers', key: 'teachers' },
+        { path: '/api/timetable/subjects', key: 'subjects' },
+        { path: '/api/timetable/rooms',    key: 'rooms' },
+        { path: '/api/timetable/groups',   key: 'groups' },
+      ];
+
+      for (const { path, key } of endpoints) {
+        jest.clearAllMocks();
+        mockListResponse([], 0);
+
+        const res = await request(app).get(path);
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data[key]).toBeInstanceOf(Array);
+        expect(res.body.data).toHaveProperty('total');
+        expect(res.body.data).toHaveProperty('page');
+        expect(res.body.data).toHaveProperty('limit');
+      }
+    });
+  });
+});

--- a/smart-campus-backend/package-lock.json
+++ b/smart-campus-backend/package-lock.json
@@ -64,7 +64,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1501,7 +1500,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1878,7 +1876,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2634,7 +2631,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5282,7 +5278,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/smart-campus-backend/src/components/timetable/timetable.controller.js
+++ b/smart-campus-backend/src/components/timetable/timetable.controller.js
@@ -1,7 +1,43 @@
 const { query } = require('../../config/db');
 const { asyncHandler, ApiError } = require('../../middleware/errorHandler');
 const { logger } = require('../../config/db');
+const { parsePagination } = require('../../utils/request');
 const timetableReadService = require('./timetable.read.service');
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * Validates and parses page, limit, sort, and order query params.
+ * Throws ApiError 400 for invalid values.
+ *
+ * @param {object} queryParams - req.query
+ * @param {string} table       - Key into ALLOWED_SORT (e.g. 'teachers')
+ */
+const validatePaginationSort = (queryParams, table) => {
+  const { page: rawPage = '1', limit: rawLimit = String(DEFAULT_LIMIT), sort, order } = queryParams;
+
+  const { page, limit, offset } = parsePagination(rawPage, rawLimit);
+
+  if (!Number.isInteger(page) || page < 1) {
+    throw new ApiError(400, 'page must be a positive integer');
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new ApiError(400, `limit must be a positive integer no greater than ${MAX_LIMIT}`);
+  }
+
+  const allowedFields = timetableReadService.ALLOWED_SORT[table];
+  if (sort && !allowedFields.includes(sort)) {
+    throw new ApiError(400, `Invalid sort field. Allowed values: ${allowedFields.join(', ')}`);
+  }
+
+  const normalizedOrder = order ? order.toLowerCase() : 'asc';
+  if (!['asc', 'desc'].includes(normalizedOrder)) {
+    throw new ApiError(400, 'order must be "asc" or "desc"');
+  }
+
+  return { page, limit, offset, sort, order: normalizedOrder };
+};
 
 /**
  * Timetable Controller
@@ -16,11 +52,12 @@ const timetableReadService = require('./timetable.read.service');
  */
 const getAllTeachers = asyncHandler(async (req, res) => {
   const { department } = req.query;
-  const teachers = await timetableReadService.listTeachers({ department });
+  const { page, limit, offset, sort, order } = validatePaginationSort(req.query, 'teachers');
+  const { rows: teachers, total } = await timetableReadService.listTeachers({ department, sort, order, limit, offset });
   
   res.json({
     success: true,
-    data: { teachers, count: teachers.length }
+    data: { teachers, count: teachers.length, total, page, limit }
   });
 });
 
@@ -30,11 +67,12 @@ const getAllTeachers = asyncHandler(async (req, res) => {
  */
 const getAllSubjects = asyncHandler(async (req, res) => {
   const { department, semester } = req.query;
-  const subjects = await timetableReadService.listSubjects({ department, semester });
+  const { page, limit, offset, sort, order } = validatePaginationSort(req.query, 'subjects');
+  const { rows: subjects, total } = await timetableReadService.listSubjects({ department, semester, sort, order, limit, offset });
   
   res.json({
     success: true,
-    data: { subjects, count: subjects.length }
+    data: { subjects, count: subjects.length, total, page, limit }
   });
 });
 
@@ -44,11 +82,12 @@ const getAllSubjects = asyncHandler(async (req, res) => {
  */
 const getAllRooms = asyncHandler(async (req, res) => {
   const { room_type } = req.query;
-  const rooms = await timetableReadService.listRooms({ room_type });
+  const { page, limit, offset, sort, order } = validatePaginationSort(req.query, 'rooms');
+  const { rows: rooms, total } = await timetableReadService.listRooms({ room_type, sort, order, limit, offset });
   
   res.json({
     success: true,
-    data: { rooms, count: rooms.length }
+    data: { rooms, count: rooms.length, total, page, limit }
   });
 });
 
@@ -58,11 +97,12 @@ const getAllRooms = asyncHandler(async (req, res) => {
  */
 const getAllGroups = asyncHandler(async (req, res) => {
   const { department, semester } = req.query;
-  const groups = await timetableReadService.listGroups({ department, semester });
+  const { page, limit, offset, sort, order } = validatePaginationSort(req.query, 'student_groups');
+  const { rows: groups, total } = await timetableReadService.listGroups({ department, semester, sort, order, limit, offset });
   
   res.json({
     success: true,
-    data: { groups, count: groups.length }
+    data: { groups, count: groups.length, total, page, limit }
   });
 });
 

--- a/smart-campus-backend/src/components/timetable/timetable.read.service.js
+++ b/smart-campus-backend/src/components/timetable/timetable.read.service.js
@@ -12,71 +12,135 @@ const DAY_ORDER_SQL = `
   END
 `;
 
-const buildActiveEntityQuery = ({ table, orderBy, filters = [] }) => {
-  const values = [];
-  let sql = `SELECT * FROM ${table} WHERE is_active = true`;
+/**
+ * Whitelisted sort columns per table.
+ * Used by the controller to validate the `sort` query parameter.
+ */
+const ALLOWED_SORT = {
+  teachers: ['full_name', 'department', 'teacher_code', 'created_at'],
+  subjects: ['subject_name', 'subject_code', 'department', 'semester', 'created_at'],
+  rooms: ['room_name', 'room_code', 'room_type', 'capacity', 'created_at'],
+  student_groups: ['group_name', 'group_code', 'department', 'semester', 'created_at'],
+};
+
+/**
+ * Builds data and count SQL queries for an active-entity listing.
+ * Returns separate value arrays for the count and data queries.
+ *
+ * @param {object} opts
+ * @param {string}   opts.table          - Table name
+ * @param {string}   opts.defaultOrderBy - Column used when no `sort` is supplied
+ * @param {Array}    opts.filters        - [{ column, value, transform? }]
+ * @param {string}   [opts.sort]         - Pre-validated sort column
+ * @param {string}   [opts.order]        - 'asc' | 'desc'
+ * @param {number}   opts.limit
+ * @param {number}   opts.offset
+ */
+const buildActiveEntityQuery = ({ table, defaultOrderBy, filters = [], sort, order, limit, offset }) => {
+  const filterValues = [];
+  let conditions = `WHERE is_active = true`;
 
   filters.forEach((filter) => {
     const value = filter.transform ? filter.transform(filter.value) : filter.value;
     if (value != null && value !== '') {
-      values.push(value);
-      sql += ` AND ${filter.column} = $${values.length}`;
+      filterValues.push(value);
+      conditions += ` AND ${filter.column} = $${filterValues.length}`;
     }
   });
 
-  sql += ` ORDER BY ${orderBy} ASC`;
+  const sortField = sort || defaultOrderBy;
+  const sortOrder = order === 'desc' ? 'DESC' : 'ASC';
 
-  return { sql, values };
+  const countSql = `SELECT COUNT(*) FROM ${table} ${conditions}`;
+
+  const limitIdx = filterValues.length + 1;
+  const offsetIdx = filterValues.length + 2;
+  const dataSql = `SELECT * FROM ${table} ${conditions} ORDER BY ${sortField} ${sortOrder} LIMIT $${limitIdx} OFFSET $${offsetIdx}`;
+  const dataValues = [...filterValues, limit, offset];
+
+  return { dataSql, countSql, filterValues, dataValues };
 };
 
-const listTeachers = async ({ department }) => {
-  const { sql, values } = buildActiveEntityQuery({
+const listTeachers = async ({ department, sort, order, limit, offset }) => {
+  const { dataSql, countSql, filterValues, dataValues } = buildActiveEntityQuery({
     table: 'teachers',
-    orderBy: 'full_name',
-    filters: [{ column: 'department', value: department }]
+    defaultOrderBy: 'full_name',
+    filters: [{ column: 'department', value: department }],
+    sort,
+    order,
+    limit,
+    offset,
   });
 
-  const result = await query(sql, values);
-  return result.rows;
+  const [dataResult, countResult] = await Promise.all([
+    query(dataSql, dataValues),
+    query(countSql, filterValues),
+  ]);
+
+  return { rows: dataResult.rows, total: parseInt(countResult.rows[0].count, 10) };
 };
 
-const listSubjects = async ({ department, semester }) => {
-  const { sql, values } = buildActiveEntityQuery({
+const listSubjects = async ({ department, semester, sort, order, limit, offset }) => {
+  const { dataSql, countSql, filterValues, dataValues } = buildActiveEntityQuery({
     table: 'subjects',
-    orderBy: 'subject_name',
+    defaultOrderBy: 'subject_name',
     filters: [
       { column: 'department', value: department },
-      { column: 'semester', value: semester, transform: parseInteger }
-    ]
+      { column: 'semester', value: semester, transform: parseInteger },
+    ],
+    sort,
+    order,
+    limit,
+    offset,
   });
 
-  const result = await query(sql, values);
-  return result.rows;
+  const [dataResult, countResult] = await Promise.all([
+    query(dataSql, dataValues),
+    query(countSql, filterValues),
+  ]);
+
+  return { rows: dataResult.rows, total: parseInt(countResult.rows[0].count, 10) };
 };
 
-const listRooms = async ({ room_type }) => {
-  const { sql, values } = buildActiveEntityQuery({
+const listRooms = async ({ room_type, sort, order, limit, offset }) => {
+  const { dataSql, countSql, filterValues, dataValues } = buildActiveEntityQuery({
     table: 'rooms',
-    orderBy: 'room_name',
-    filters: [{ column: 'room_type', value: room_type }]
+    defaultOrderBy: 'room_name',
+    filters: [{ column: 'room_type', value: room_type }],
+    sort,
+    order,
+    limit,
+    offset,
   });
 
-  const result = await query(sql, values);
-  return result.rows;
+  const [dataResult, countResult] = await Promise.all([
+    query(dataSql, dataValues),
+    query(countSql, filterValues),
+  ]);
+
+  return { rows: dataResult.rows, total: parseInt(countResult.rows[0].count, 10) };
 };
 
-const listGroups = async ({ department, semester }) => {
-  const { sql, values } = buildActiveEntityQuery({
+const listGroups = async ({ department, semester, sort, order, limit, offset }) => {
+  const { dataSql, countSql, filterValues, dataValues } = buildActiveEntityQuery({
     table: 'student_groups',
-    orderBy: 'group_name',
+    defaultOrderBy: 'group_name',
     filters: [
       { column: 'department', value: department },
-      { column: 'semester', value: semester, transform: parseInteger }
-    ]
+      { column: 'semester', value: semester, transform: parseInteger },
+    ],
+    sort,
+    order,
+    limit,
+    offset,
   });
 
-  const result = await query(sql, values);
-  return result.rows;
+  const [dataResult, countResult] = await Promise.all([
+    query(dataSql, dataValues),
+    query(countSql, filterValues),
+  ]);
+
+  return { rows: dataResult.rows, total: parseInt(countResult.rows[0].count, 10) };
 };
 
 const getGroupTimetable = async ({ groupId, academic_year, semester_type }) => {
@@ -151,6 +215,7 @@ const getConfigData = async () => {
 };
 
 module.exports = {
+  ALLOWED_SORT,
   listTeachers,
   listSubjects,
   listRooms,

--- a/smart-campus-backend/src/middleware/rateLimiter.middleware.js
+++ b/smart-campus-backend/src/middleware/rateLimiter.middleware.js
@@ -5,7 +5,7 @@ const rateLimit = require('express-rate-limit');
  * Applied to all /api routes by default
  */
 const apiLimiter = rateLimit({
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes 
   max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100,
   skip: () => process.env.NODE_ENV === 'test',
   message: {

--- a/smart-campus-backend/src/middleware/rateLimiter.middleware.js
+++ b/smart-campus-backend/src/middleware/rateLimiter.middleware.js
@@ -7,6 +7,7 @@ const rateLimit = require('express-rate-limit');
 const apiLimiter = rateLimit({
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
   max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100,
+  skip: () => process.env.NODE_ENV === 'test',
   message: {
     success: false,
     error: 'Too many requests from this IP, please try again later.',
@@ -22,6 +23,7 @@ const apiLimiter = rateLimit({
 const authLimiter = rateLimit({
   windowMs: parseInt(process.env.AUTH_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
   max: parseInt(process.env.AUTH_RATE_LIMIT_MAX_REQUESTS) || 5, // 5 attempts per window
+  skip: () => process.env.NODE_ENV === 'test',
   message: {
     success: false,
     error: 'Too many authentication attempts. Please try again after 15 minutes.',

--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -161,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -312,7 +313,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -357,7 +357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2667,7 +2666,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -3231,6 +3229,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3250,6 +3249,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3258,7 +3258,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -3316,7 +3317,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3421,7 +3423,6 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3443,7 +3444,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3455,7 +3455,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3480,7 +3479,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
       "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3543,7 +3541,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3908,7 +3905,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4198,7 +4194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4688,7 +4683,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4753,6 +4747,7 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4837,8 +4832,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4998,7 +4992,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5953,7 +5946,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -6607,6 +6599,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7005,7 +6998,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7050,7 +7042,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7196,6 +7187,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7210,6 +7202,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7219,6 +7212,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7230,7 +7224,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -7299,7 +7294,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7338,7 +7332,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7352,7 +7345,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8092,7 +8084,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8159,8 +8150,7 @@
       "version": "0.160.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
       "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -8421,7 +8411,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8609,7 +8598,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/smart-campus-frontend/src/hooks/useAdminCrud.ts
+++ b/smart-campus-frontend/src/hooks/useAdminCrud.ts
@@ -71,7 +71,7 @@ export function useAdminCrud<T extends { id: string }>({
     try {
       await deleteById(id);
       toast.success(onDeleteSuccessMessage || `${entityNameTitle} deleted successfully`);
-      onRefresh ? onRefresh() : loadItems();
+      if (onRefresh) { onRefresh(); } else { loadItems(); }
     } catch (error: any) {
       toast.error(onDeleteErrorMessage || error?.message || `Failed to delete ${entityName}`);
     }
@@ -79,7 +79,7 @@ export function useAdminCrud<T extends { id: string }>({
 
   const handleFormSuccess = () => {
     setIsModalOpen(false);
-    onRefresh ? onRefresh() : loadItems();
+    if (onRefresh) { onRefresh(); } else { loadItems(); }
   };
 
   return {

--- a/smart-campus-frontend/src/hooks/useAdminCrud.ts
+++ b/smart-campus-frontend/src/hooks/useAdminCrud.ts
@@ -10,6 +10,8 @@ interface UseAdminCrudOptions<T extends { id: string }> {
   onDeleteErrorMessage?: string;
   onDeleteSuccessMessage?: string;
   autoLoad?: boolean;
+  /** When provided, called after delete/form-success instead of the internal loadItems. */
+  onRefresh?: () => void;
 }
 
 const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
@@ -23,6 +25,7 @@ export function useAdminCrud<T extends { id: string }>({
   onDeleteErrorMessage,
   onDeleteSuccessMessage,
   autoLoad = true,
+  onRefresh,
 }: UseAdminCrudOptions<T>) {
   const [items, setItems] = useState<T[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -68,7 +71,7 @@ export function useAdminCrud<T extends { id: string }>({
     try {
       await deleteById(id);
       toast.success(onDeleteSuccessMessage || `${entityNameTitle} deleted successfully`);
-      loadItems();
+      onRefresh ? onRefresh() : loadItems();
     } catch (error: any) {
       toast.error(onDeleteErrorMessage || error?.message || `Failed to delete ${entityName}`);
     }
@@ -76,7 +79,7 @@ export function useAdminCrud<T extends { id: string }>({
 
   const handleFormSuccess = () => {
     setIsModalOpen(false);
-    loadItems();
+    onRefresh ? onRefresh() : loadItems();
   };
 
   return {

--- a/smart-campus-frontend/src/pages/admin/Rooms.tsx
+++ b/smart-campus-frontend/src/pages/admin/Rooms.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Button } from '@/components/ui/button';
@@ -6,11 +7,48 @@ import { roomService } from '@/services/roomService';
 import { FormModal } from '@/components/modals/FormModal';
 import { RoomForm } from '@/components/forms/RoomForm';
 import { useAdminCrud } from '@/hooks/useAdminCrud';
-import { useSortedPagination } from '@/hooks/useSortedPagination';
+import { toast } from 'sonner';
+
+const ITEMS_PER_PAGE = 10;
 
 export default function Rooms() {
+  const [rooms, setRooms] = useState<any[]>([]);
+  const [total, setTotal] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortField, setSortField] = useState('room_code');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const loadRooms = useCallback(async () => {
+    try {
+      const result = await roomService.list({
+        page: currentPage,
+        limit: ITEMS_PER_PAGE,
+        sort: sortField,
+        order: sortDirection,
+      });
+      setRooms(result.items);
+      setTotal(result.total);
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to load rooms');
+      setRooms([]);
+    }
+  }, [currentPage, sortField, sortDirection]);
+
+  useEffect(() => {
+    loadRooms();
+  }, [loadRooms]);
+
+  const handleSort = (field: string) => {
+    if (sortField === field) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+    setCurrentPage(1);
+  };
+
   const {
-    items: rooms,
     isModalOpen,
     selectedItem: editingRoom,
     openCreate,
@@ -24,20 +62,11 @@ export default function Rooms() {
     entityName: 'room',
     confirmDeleteMessage: 'Are you sure you want to delete this room?',
     onDeleteSuccessMessage: 'Room deleted successfully!',
+    autoLoad: false,
+    onRefresh: loadRooms,
   });
-  const {
-    currentPage,
-    setCurrentPage,
-    sortField,
-    sortDirection,
-    handleSort,
-    paginatedItems: paginatedRooms,
-    totalPages,
-  } = useSortedPagination<any>({
-    items: rooms,
-    initialSortField: 'room_code',
-    itemsPerPage: 10,
-  });
+
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
 
   return (
     <DashboardLayout>
@@ -89,8 +118,11 @@ export default function Rooms() {
                   >
                     Type {sortField === 'room_type' && (sortDirection === 'asc' ? '↑' : '↓')}
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">
-                    Capacity
+                  <th 
+                    className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-accent/20"
+                    onClick={() => handleSort('capacity')}
+                  >
+                    Capacity {sortField === 'capacity' && (sortDirection === 'asc' ? '↑' : '↓')}
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">
                     Location
@@ -101,7 +133,7 @@ export default function Rooms() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/50">
-                {paginatedRooms.map((room: any) => (
+                {rooms.map((room: any) => (
                   <motion.tr
                     key={room.id}
                     initial={{ opacity: 0 }}
@@ -137,16 +169,18 @@ export default function Rooms() {
             </table>
           </div>
 
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between px-6 py-4 border-t border-border/50">
-              <div className="text-sm text-muted-foreground">
-                Page {currentPage} of {totalPages}
-              </div>
+          <div className="flex items-center justify-between px-6 py-4 border-t border-border/50">
+            <div className="text-sm text-muted-foreground">
+              {total > 0
+                ? `Showing ${(currentPage - 1) * ITEMS_PER_PAGE + 1}–${Math.min(currentPage * ITEMS_PER_PAGE, total)} of ${total}`
+                : 'No rooms found'}
+            </div>
+            {totalPages > 1 && (
               <div className="flex gap-2">
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                   disabled={currentPage === 1}
                 >
                   Previous
@@ -154,14 +188,14 @@ export default function Rooms() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                   disabled={currentPage === totalPages}
                 >
                   Next
                 </Button>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </motion.div>
 

--- a/smart-campus-frontend/src/pages/admin/Subjects.tsx
+++ b/smart-campus-frontend/src/pages/admin/Subjects.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Button } from '@/components/ui/button';
@@ -22,6 +22,7 @@ import { FormModal } from '@/components/modals/FormModal';
 import { SubjectForm } from '@/components/forms/SubjectForm';
 import { subjectService } from '@/services/subjectService';
 import { useAdminCrud } from '@/hooks/useAdminCrud';
+import { toast } from 'sonner';
 
 interface Subject {
   id: string;
@@ -36,10 +37,47 @@ interface Subject {
   department: string;
 }
 
+const ITEMS_PER_PAGE = 10;
+
 export default function Subjects() {
   const [search, setSearch] = useState('');
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+  const [total, setTotal] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortField, setSortField] = useState('subject_name');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const loadSubjects = useCallback(async () => {
+    try {
+      const result = await subjectService.list({
+        page: currentPage,
+        limit: ITEMS_PER_PAGE,
+        sort: sortField,
+        order: sortDirection,
+      });
+      setSubjects(result.items as Subject[]);
+      setTotal(result.total);
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to load subjects');
+      setSubjects([]);
+    }
+  }, [currentPage, sortField, sortDirection]);
+
+  useEffect(() => {
+    loadSubjects();
+  }, [loadSubjects]);
+
+  const handleSort = (field: string) => {
+    if (sortField === field) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+    setCurrentPage(1);
+  };
+
   const {
-    items: subjects,
     isModalOpen,
     selectedItem: selectedSubject,
     openCreate,
@@ -51,6 +89,8 @@ export default function Subjects() {
     getAll: subjectService.getAll,
     deleteById: subjectService.delete,
     entityName: 'subject',
+    autoLoad: false,
+    onRefresh: loadSubjects,
   });
 
   const filteredSubjects = subjects.filter((subject) => {
@@ -61,6 +101,8 @@ export default function Subjects() {
       subject.department?.toLowerCase().includes(q)
     );
   });
+
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
 
   return (
     <DashboardLayout>
@@ -106,10 +148,30 @@ export default function Subjects() {
             <Table>
               <TableHeader>
                 <TableRow className="hover:bg-accent/5">
-                  <TableHead>Code</TableHead>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Credits</TableHead>
-                  <TableHead>Department</TableHead>
+                  <TableHead
+                    className="cursor-pointer hover:bg-accent/20"
+                    onClick={() => handleSort('subject_code')}
+                  >
+                    Code {sortField === 'subject_code' && (sortDirection === 'asc' ? '↑' : '↓')}
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer hover:bg-accent/20"
+                    onClick={() => handleSort('subject_name')}
+                  >
+                    Name {sortField === 'subject_name' && (sortDirection === 'asc' ? '↑' : '↓')}
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer hover:bg-accent/20"
+                    onClick={() => handleSort('semester')}
+                  >
+                    Credits {sortField === 'semester' && (sortDirection === 'asc' ? '↑' : '↓')}
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer hover:bg-accent/20"
+                    onClick={() => handleSort('department')}
+                  >
+                    Department {sortField === 'department' && (sortDirection === 'asc' ? '↑' : '↓')}
+                  </TableHead>
                   <TableHead className="w-[50px]"></TableHead>
                 </TableRow>
               </TableHeader>
@@ -152,6 +214,34 @@ export default function Subjects() {
                 )}
               </TableBody>
             </Table>
+          </div>
+
+          <div className="flex items-center justify-between mt-4">
+            <div className="text-sm text-muted-foreground">
+              {total > 0
+                ? `Showing ${(currentPage - 1) * ITEMS_PER_PAGE + 1}–${Math.min(currentPage * ITEMS_PER_PAGE, total)} of ${total}`
+                : 'No subjects found'}
+            </div>
+            {totalPages > 1 && (
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
           </div>
         </div>
 

--- a/smart-campus-frontend/src/pages/admin/Subjects.tsx
+++ b/smart-campus-frontend/src/pages/admin/Subjects.tsx
@@ -160,12 +160,7 @@ export default function Subjects() {
                   >
                     Name {sortField === 'subject_name' && (sortDirection === 'asc' ? '↑' : '↓')}
                   </TableHead>
-                  <TableHead
-                    className="cursor-pointer hover:bg-accent/20"
-                    onClick={() => handleSort('semester')}
-                  >
-                    Credits {sortField === 'semester' && (sortDirection === 'asc' ? '↑' : '↓')}
-                  </TableHead>
+                  <TableHead>Credits</TableHead>
                   <TableHead
                     className="cursor-pointer hover:bg-accent/20"
                     onClick={() => handleSort('department')}

--- a/smart-campus-frontend/src/pages/admin/Teachers.tsx
+++ b/smart-campus-frontend/src/pages/admin/Teachers.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Button } from '@/components/ui/button';
@@ -6,11 +7,48 @@ import { teacherService } from '@/services/teacherService';
 import { FormModal } from '@/components/modals/FormModal';
 import { TeacherForm } from '@/components/forms/TeacherForm';
 import { useAdminCrud } from '@/hooks/useAdminCrud';
-import { useSortedPagination } from '@/hooks/useSortedPagination';
+import { toast } from 'sonner';
+
+const ITEMS_PER_PAGE = 10;
 
 export default function Teachers() {
+  const [teachers, setTeachers] = useState<any[]>([]);
+  const [total, setTotal] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortField, setSortField] = useState('full_name');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const loadTeachers = useCallback(async () => {
+    try {
+      const result = await teacherService.list({
+        page: currentPage,
+        limit: ITEMS_PER_PAGE,
+        sort: sortField,
+        order: sortDirection,
+      });
+      setTeachers(result.items);
+      setTotal(result.total);
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to load teachers');
+      setTeachers([]);
+    }
+  }, [currentPage, sortField, sortDirection]);
+
+  useEffect(() => {
+    loadTeachers();
+  }, [loadTeachers]);
+
+  const handleSort = (field: string) => {
+    if (sortField === field) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+    setCurrentPage(1);
+  };
+
   const {
-    items: teachers,
     isModalOpen,
     selectedItem: editingTeacher,
     openCreate,
@@ -24,20 +62,11 @@ export default function Teachers() {
     entityName: 'teacher',
     confirmDeleteMessage: 'Are you sure you want to delete this teacher?',
     onDeleteSuccessMessage: 'Teacher deleted successfully!',
+    autoLoad: false,
+    onRefresh: loadTeachers,
   });
-  const {
-    currentPage,
-    setCurrentPage,
-    sortField,
-    sortDirection,
-    handleSort,
-    paginatedItems: paginatedTeachers,
-    totalPages,
-  } = useSortedPagination<any>({
-    items: teachers,
-    initialSortField: 'full_name',
-    itemsPerPage: 10,
-  });
+
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
 
   return (
     <DashboardLayout>
@@ -98,7 +127,7 @@ export default function Teachers() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/50">
-                {paginatedTeachers.map((teacher: any) => (
+                {teachers.map((teacher: any) => (
                   <motion.tr
                     key={teacher.id}
                     initial={{ opacity: 0 }}
@@ -134,16 +163,18 @@ export default function Teachers() {
             </table>
           </div>
 
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between px-6 py-4 border-t border-border/50">
-              <div className="text-sm text-muted-foreground">
-                Page {currentPage} of {totalPages}
-              </div>
+          <div className="flex items-center justify-between px-6 py-4 border-t border-border/50">
+            <div className="text-sm text-muted-foreground">
+              {total > 0
+                ? `Showing ${(currentPage - 1) * ITEMS_PER_PAGE + 1}–${Math.min(currentPage * ITEMS_PER_PAGE, total)} of ${total}`
+                : 'No teachers found'}
+            </div>
+            {totalPages > 1 && (
               <div className="flex gap-2">
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                   disabled={currentPage === 1}
                 >
                   Previous
@@ -151,14 +182,14 @@ export default function Teachers() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                   disabled={currentPage === totalPages}
                 >
                   Next
                 </Button>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </motion.div>
 

--- a/smart-campus-frontend/src/services/roomService.ts
+++ b/smart-campus-frontend/src/services/roomService.ts
@@ -1,4 +1,4 @@
-import { timetableService } from './timetableService';
+import { timetableService, PaginationSortParams } from './timetableService';
 import { api } from '@/lib/axios';
 import { getPayload, getPayloadArray } from './serviceUtils';
 
@@ -6,6 +6,16 @@ export const roomService = {
   getAll: async () => {
     const response = await timetableService.getRooms();
     return getPayloadArray<any>(response, 'rooms');
+  },
+
+  list: async (params: PaginationSortParams) => {
+    const response = await timetableService.getRooms('', params);
+    return {
+      items: getPayloadArray<any>(response, 'rooms'),
+      total: (response?.data?.total as number) ?? 0,
+      page: (response?.data?.page as number) ?? (params.page ?? 1),
+      limit: (response?.data?.limit as number) ?? (params.limit ?? 20),
+    };
   },
 
   create: async (roomData: any) => {

--- a/smart-campus-frontend/src/services/subjectService.ts
+++ b/smart-campus-frontend/src/services/subjectService.ts
@@ -1,4 +1,4 @@
-import { timetableService } from './timetableService';
+import { timetableService, PaginationSortParams } from './timetableService';
 import { api } from '@/lib/axios';
 import { getPayload, getPayloadArray } from './serviceUtils';
 
@@ -14,6 +14,17 @@ export const subjectService = {
     const response = await timetableService.getSubjects();
     const subjects = getPayloadArray<any>(response, 'subjects');
     return subjects.map(normalizeSubject);
+  },
+
+  list: async (params: PaginationSortParams) => {
+    const response = await timetableService.getSubjects({}, params);
+    const subjects = getPayloadArray<any>(response, 'subjects');
+    return {
+      items: subjects.map(normalizeSubject),
+      total: (response?.data?.total as number) ?? 0,
+      page: (response?.data?.page as number) ?? (params.page ?? 1),
+      limit: (response?.data?.limit as number) ?? (params.limit ?? 20),
+    };
   },
 
   create: async (subjectData: any) => {

--- a/smart-campus-frontend/src/services/teacherService.ts
+++ b/smart-campus-frontend/src/services/teacherService.ts
@@ -1,4 +1,4 @@
-import { timetableService } from './timetableService';
+import { timetableService, PaginationSortParams } from './timetableService';
 import { api } from '@/lib/axios';
 import { getPayload, getPayloadArray } from './serviceUtils';
 
@@ -6,6 +6,16 @@ export const teacherService = {
   getAll: async () => {
     const response = await timetableService.getTeachers();
     return getPayloadArray<any>(response, 'teachers');
+  },
+
+  list: async (params: PaginationSortParams) => {
+    const response = await timetableService.getTeachers('', params);
+    return {
+      items: getPayloadArray<any>(response, 'teachers'),
+      total: (response?.data?.total as number) ?? 0,
+      page: (response?.data?.page as number) ?? (params.page ?? 1),
+      limit: (response?.data?.limit as number) ?? (params.limit ?? 20),
+    };
   },
 
   create: async (teacherData: any) => {

--- a/smart-campus-frontend/src/services/timetableService.ts
+++ b/smart-campus-frontend/src/services/timetableService.ts
@@ -57,15 +57,40 @@ export interface Group {
   updated_at?: string;
 }
 
+/** Shared query params for server-side pagination and sorting. */
+export interface PaginationSortParams {
+  page?: number;
+  limit?: number;
+  sort?: string;
+  order?: 'asc' | 'desc';
+}
+
+/** Shape of the pagination metadata returned by list endpoints. */
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+}
+
+const buildQueryString = (params: Record<string, string | number | undefined>): string => {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  }
+  const qs = searchParams.toString();
+  return qs ? `?${qs}` : '';
+};
+
 export const timetableService = {
   /**
    * Get all teachers
-   * GET /api/timetable/teachers?department=Computer%20Science
-   * @param department - Optional department filter
+   * GET /api/timetable/teachers?department=...&page=1&limit=20&sort=full_name&order=asc
    */
-  getTeachers: async (department = '') => {
+  getTeachers: async (department = '', pagination: PaginationSortParams = {}) => {
     try {
-      const query = department ? `?department=${encodeURIComponent(department)}` : '';
+      const query = buildQueryString({ department, ...pagination });
       const { data } = await api.get(`/timetable/teachers${query}`);
       return data;
     } catch (error: any) {
@@ -75,15 +100,14 @@ export const timetableService = {
 
   /**
    * Get all subjects
-   * GET /api/timetable/subjects?department=Computer%20Science&semester=5
-   * @param filters - { department?, semester? }
+   * GET /api/timetable/subjects?department=...&semester=5&page=1&limit=20&sort=subject_name&order=asc
    */
-  getSubjects: async (filters: { department?: string; semester?: number } = {}) => {
+  getSubjects: async (
+    filters: { department?: string; semester?: number } = {},
+    pagination: PaginationSortParams = {}
+  ) => {
     try {
-      const params = new URLSearchParams();
-      if (filters.department) params.append('department', filters.department);
-      if (filters.semester) params.append('semester', filters.semester.toString());
-      const query = params.toString() ? `?${params.toString()}` : '';
+      const query = buildQueryString({ ...filters, ...pagination });
       const { data } = await api.get(`/timetable/subjects${query}`);
       return data;
     } catch (error: any) {
@@ -93,12 +117,11 @@ export const timetableService = {
 
   /**
    * Get all rooms
-   * GET /api/timetable/rooms?room_type=Lab
-   * @param roomType - Optional room type filter
+   * GET /api/timetable/rooms?room_type=Lab&page=1&limit=20&sort=room_name&order=asc
    */
-  getRooms: async (roomType = '') => {
+  getRooms: async (roomType = '', pagination: PaginationSortParams = {}) => {
     try {
-      const query = roomType ? `?room_type=${encodeURIComponent(roomType)}` : '';
+      const query = buildQueryString({ room_type: roomType, ...pagination });
       const { data } = await api.get(`/timetable/rooms${query}`);
       return data;
     } catch (error: any) {
@@ -108,15 +131,14 @@ export const timetableService = {
 
   /**
    * Get all student groups
-   * GET /api/timetable/groups?department=Computer%20Science&semester=5
-   * @param filters - { department?, semester? }
+   * GET /api/timetable/groups?department=...&semester=5&page=1&limit=20&sort=group_name&order=asc
    */
-  getGroups: async (filters: { department?: string; semester?: number } = {}) => {
+  getGroups: async (
+    filters: { department?: string; semester?: number } = {},
+    pagination: PaginationSortParams = {}
+  ) => {
     try {
-      const params = new URLSearchParams();
-      if (filters.department) params.append('department', filters.department);
-      if (filters.semester) params.append('semester', filters.semester.toString());
-      const query = params.toString() ? `?${params.toString()}` : '';
+      const query = buildQueryString({ ...filters, ...pagination });
       const { data } = await api.get(`/timetable/groups${query}`);
       return data;
     } catch (error: any) {


### PR DESCRIPTION
# NSoC '26

## closes Issues #62 

## Summary

Adds server-side pagination and sorting to all four timetable resource listing APIs
(Teachers, Subjects, Rooms, Student Groups) and updates the React admin screens to
consume the new server-driven data. Also fixes a UI bug where the non-sortable
**Credits** column in the Subjects table had an erroneous sort click-handler.

---

## Changes

### Backend (`smart-campus-backend`)

**`timetable.read.service.js`**
- Added `ALLOWED_SORT` allowlist per table to guard against SQL injection via
  sort-column injection.
- Refactored each `list*` function to accept `page`, `limit`, `sortBy`, `sortOrder`
  and run the data query + `COUNT(*)` query in parallel (`Promise.all`), returning
  `{ rows, total }`.

**`timetable.controller.js`**
- Added `validatePaginationSort` helper: validates `page`/`limit` (positive integers,
  `limit ≤ 100`) and `sort`/`order` (whitelisted per entity); throws `ApiError 400`
  on invalid input.
- All four list handlers (`getAllTeachers`, `getAllSubjects`, `getAllRooms`,
  `getAllGroups`) now extract, validate, and forward pagination/sort params; response
  shape includes `{ count, total, page, limit }` metadata.

**`__tests__/timetable-pagination.test.js`** *(new)*
- 28 test cases covering valid pagination, valid sorting, invalid inputs (→ 400),
  boundary cases (page beyond total), and combined filter + pagination + sort.

**`timetable-generation.test.js` / `timetable-electives.test.js`**
- Updated list-endpoint mocks to stub both the data query and the new count query
  (`Promisie.all` pattern requires two `mockResolvedValueOnce` calls).

---

### Frontend (`smart-campus-frontend`)

**`timetableService.ts`**
- Added `PaginationSortParams` and `PaginationMeta` interfaces.
- `getTeachers`, `getSubjects`, `getRooms`, `getGroups` now accept optional params
  and append them to the query string via `URLSearchParams`.

**`teacherService.ts` / `roomService.ts` / `subjectService.ts`**
- Added `list(params)` method returning `{ items, total, page, limit }`.

**`useAdminCrud.ts`**
- Added optional `onRefresh` callback; called after delete/form-success to allow
  caller-controlled refresh that preserves full pagination state.

**`Teachers.tsx` / `Rooms.tsx` / `Subjects.tsx`**
- Replaced client-side full-array slicing with server-driven fetching via local
  `page` / `sort` / `order` state.
- Sortable column headers show `↑`/`↓` indicators and reset to page 1 on change.
- Pagination controls display `Showing X–Y of Z` using server-supplied `total`.

**`Subjects.tsx` (bug fix)**
- Removed `onClick` sort handler from the **Credits** column header — it was
  incorrectly mutating sort state despite Credits not being a backend sort field.

---

## How to test

```bash
# Backend
cd smart-campus-backend
JWT_SECRET=test npx jest          # all tests including new pagination suite

# Frontend
cd smart-campus-frontend
npm run build                     # type-checks pass