### PR TITLE
feat(events): add retry button for Saved Events error state #60

### DIFF
--- a/smart-campus-frontend/src/pages/student/SavedEvents.tsx
+++ b/smart-campus-frontend/src/pages/student/SavedEvents.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Calendar, MapPin, Clock, Bookmark, AlertCircle, Loader } from 'lucide-react';
+import { Calendar, MapPin, Clock, Bookmark, AlertCircle, Loader, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { eventsService, SavedEvent } from '@/services/eventService';
 
@@ -23,8 +23,8 @@ export default function SavedEvents() {
       setError(null);
       const response = await eventsService.getMySaved();
       setSavedEvents(response.data?.events || []);
-    } catch (error: unknown) {
-      const e = error as { message?: string };
+    } catch (err: unknown) {
+      const e = err as { message?: string };
       const errorMsg = e?.message || 'Failed to load saved events';
       setError(errorMsg);
       toast.error(errorMsg);
@@ -66,12 +66,23 @@ export default function SavedEvents() {
 
           <Card className="glass border-destructive/50 bg-destructive/10">
             <CardContent className="pt-6">
-              <div className="flex items-center gap-3 text-destructive">
-                <AlertCircle className="h-6 w-6" />
-                <div>
-                  <h3 className="font-semibold">Error Loading Saved Events</h3>
-                  <p className="text-sm">{error}</p>
+              <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <div className="flex items-center gap-3 text-destructive">
+                  <AlertCircle className="h-6 w-6" />
+                  <div>
+                    <h3 className="font-semibold">Error Loading Saved Events</h3>
+                    <p className="text-sm">{error}</p>
+                  </div>
                 </div>
+                <Button 
+                  variant="destructive" 
+                  size="sm" 
+                  onClick={loadSavedEvents}
+                  className="shrink-0"
+                >
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Retry
+                </Button>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## 📝 Description
This PR addresses issue #60 by adding a "Retry" button to the error state UI on the My Saved Events page. Currently, when loading fails, users are forced to refresh the entire page manually. This change provides a direct action to re-attempt the data fetch without a full reload.

## ✨ Changes
- Added a `Retry` button to the error card in `SavedEvents.tsx`.
- Integrated the `RefreshCw` icon for better visual feedback.
- Linked the button to the existing `loadSavedEvents` function.
- Ensured a clean state reset by clearing the `error` and setting `isLoading` to true before each retry.
- Fixed a minor variable shadowing issue in the catch block for better code maintainability.
- Implemented a responsive layout for the error card content.


## 🧪 Testing
1. Navigate to `/student/saved-events`.
2. Simulate a failure (e.g., stop the backend or disconnect the DB).
3. Observe the error card and click the **Retry** button.
4. Verify the loading spinner appears and a new fetch is triggered.

## 🔗 Related Issues
Closes #60

#NSoC2026
