### PR TITLE
Prevent dark mode flash of unstyled content

### DIFF
--- a/smart-campus-frontend/index.html
+++ b/smart-campus-frontend/index.html
@@ -6,6 +6,23 @@
     <title>Smart Campus Utility Hub</title>
     <meta name="description" content="Your intelligent campus management system" />
     <meta name="author" content="Smart Campus" />
+    <script>
+      (function () {
+        try {
+          var storedTheme = localStorage.getItem('theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var theme = storedTheme === 'light' || storedTheme === 'dark'
+            ? storedTheme
+            : prefersDark ? 'dark' : 'light';
+
+          document.documentElement.classList.add(theme);
+          document.documentElement.style.colorScheme = theme;
+        } catch {
+          document.documentElement.classList.add('dark');
+          document.documentElement.style.colorScheme = 'dark';
+        }
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/smart-campus-frontend/src/contexts/ThemeContext.test.tsx
+++ b/smart-campus-frontend/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+const mockMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+const ThemeConsumer = () => {
+  const { theme } = useTheme();
+  return <span>{theme}</span>;
+};
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.style.colorScheme = '';
+  });
+
+  it('uses the saved theme before system preference', () => {
+    localStorage.setItem('theme', 'dark');
+    mockMatchMedia(false);
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('dark')).toBeInTheDocument();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('uses system dark preference when no saved theme exists', () => {
+    mockMatchMedia(true);
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('dark')).toBeInTheDocument();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/smart-campus-frontend/src/contexts/ThemeContext.tsx
+++ b/smart-campus-frontend/src/contexts/ThemeContext.tsx
@@ -9,11 +9,19 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const getInitialTheme = (): Theme => {
+  try {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    return 'dark';
+  }
+
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const stored = localStorage.getItem('theme') as Theme;
-    return stored || 'dark';
-  });
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
     const root = window.document.documentElement;


### PR DESCRIPTION
Closes #108

  #NSoC2026

  ## Summary
  - Added a blocking theme script in `index.html` to apply the saved or preferred theme before React mounts.
  - Aligned `ThemeProvider` initial state with the same saved-theme/system-preference logic.
  - Added tests for saved theme and system dark preference.

  ## Testing
  - npm run typecheck
  - npm run lint
  - npm run test

  ## Note
  `npm run build` is currently blocked by an existing unrelated duplicate `abortControllerRef` declaration in `src/components/forms/useGenericForm.ts`.