### PR TITLE
fix Student Timetable: possible invalid group selection / race behavior

### DIFF
--- a/smart-campus-frontend/src/pages/student/Timetable.tsx
+++ b/smart-campus-frontend/src/pages/student/Timetable.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
@@ -60,9 +60,31 @@ export default function StudentTimetable() {
 
   const [breakPeriods, setBreakPeriods] = useState<Set<number>>(() => new Set([4]));
 
+  const fetchAvailableGroups = async (): Promise<void> => {
+    try {
+      const response = await timetableService.getGroups();
+
+      if (response.success && response.data?.groups) {
+        const newGroups: Group[] = response.data.groups;
+        setAvailableGroups(newGroups);
+
+        // Keep current selection if still present; otherwise auto-select first group.
+        const currentIsValid = !!selectedGroup && newGroups.some((g) => g.id === selectedGroup);
+        if (!currentIsValid) {
+          setSelectedGroup(newGroups.length > 0 ? newGroups[0].id : '');
+        }
+      }
+    } catch (err: unknown) {
+      const e = err as { message?: string };
+      console.error('Error fetching groups:', e);
+      toast.error(e?.message || 'Failed to load student groups');
+    }
+  };
+
   // Fetch available groups on component mount
   useEffect(() => {
     fetchAvailableGroups();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Fetch timetable config (lunch break periods) on component mount
@@ -82,33 +104,23 @@ export default function StudentTimetable() {
     fetchConfig();
   }, []);
 
-  // Fetch timetable when group, year, or semester changes
+  const isSelectedGroupValid =
+    !!selectedGroup && availableGroups.some((g) => g.id === selectedGroup);
+
+  // Fetch timetable when group, year, or semester changes (guard against invalid group / race)
+  const latestTimetableRequestIdRef = useRef(0);
+
   useEffect(() => {
-    if (selectedGroup) {
-      fetchTimetable();
-    }
-  }, [selectedGroup, selectedAcademicYear, selectedSemesterType]);
+    if (!selectedGroup || !isSelectedGroupValid) return;
+    if (!selectedAcademicYear || !selectedSemesterType) return;
+
+    const requestId = ++latestTimetableRequestIdRef.current;
+    fetchTimetable(requestId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedGroup, selectedAcademicYear, selectedSemesterType, isSelectedGroupValid]);
 
 
-  const fetchAvailableGroups = async (): Promise<void> => {
-    try {
-      const response = await timetableService.getGroups();
-      
-      if (response.success && response.data?.groups) {
-        setAvailableGroups(response.data.groups);
-        // Auto-select first group if available
-        if (response.data.groups.length > 0) {
-          setSelectedGroup(response.data.groups[0].id);
-        }
-      }
-    } catch (err: unknown) {
-      const e = err as { message?: string };
-      console.error('Error fetching groups:', e);
-      toast.error(e?.message || 'Failed to load student groups');
-    }
-  };
-
-  const fetchTimetable = async (): Promise<void> => {
+  const fetchTimetable = async (requestId: number): Promise<void> => {
     try {
       setLoading(true);
       setError('');
@@ -118,6 +130,9 @@ export default function StudentTimetable() {
         selectedAcademicYear,
         selectedSemesterType
       );
+
+      // Ignore stale responses (race protection)
+      if (requestId !== latestTimetableRequestIdRef.current) return;
 
       if (!response.success) {
         throw new Error(response.error || 'Failed to load timetable');
@@ -155,11 +170,13 @@ export default function StudentTimetable() {
   };
 
   const handleRefresh = (): void => {
-    if (selectedGroup) {
-      fetchTimetable();
-    } else {
-      toast.error('Please select a group first');
+    if (!selectedGroup || !isSelectedGroupValid) {
+      toast.error('Please select a valid group first');
+      return;
     }
+
+    const requestId = ++latestTimetableRequestIdRef.current;
+    fetchTimetable(requestId);
   };
 
   const getCellContent = (slot: TimetableSlot | null): JSX.Element => {

--- a/smart-campus-frontend/src/pages/student/Timetable.tsx
+++ b/smart-campus-frontend/src/pages/student/Timetable.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+
 
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card } from '@/components/ui/card';
@@ -10,6 +11,7 @@ import { timetableService } from '@/services/timetableService';
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const PERIODS = [1, 2, 3, 4, 5, 6, 7, 8];
+
 
 interface TimetableSlot {
   id: string;
@@ -56,9 +58,28 @@ export default function StudentTimetable() {
   const [selectedAcademicYear, setSelectedAcademicYear] = useState<string>('2024-25');
   const [selectedSemesterType, setSelectedSemesterType] = useState<string>('odd');
 
+  const [breakPeriods, setBreakPeriods] = useState<Set<number>>(() => new Set([4]));
+
   // Fetch available groups on component mount
   useEffect(() => {
     fetchAvailableGroups();
+  }, []);
+
+  // Fetch timetable config (lunch break periods) on component mount
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await timetableService.getConfig();
+        const lunchPeriod = response?.data?.defaultLunchBreak;
+        if (typeof lunchPeriod === 'number') {
+          setBreakPeriods(new Set([lunchPeriod]));
+        }
+      } catch (e) {
+        // Keep fallback to period 4
+      }
+    };
+
+    fetchConfig();
   }, []);
 
   // Fetch timetable when group, year, or semester changes
@@ -67,6 +88,7 @@ export default function StudentTimetable() {
       fetchTimetable();
     }
   }, [selectedGroup, selectedAcademicYear, selectedSemesterType]);
+
 
   const fetchAvailableGroups = async (): Promise<void> => {
     try {
@@ -319,9 +341,10 @@ export default function StudentTimetable() {
 
                       {PERIODS.map((period) => {
                         const slot = timetableData[day]?.[period];
-                        const isLunchBreak = period === 4; // Assuming period 4 is lunch
+                        const isLunchBreak = breakPeriods.has(period);
                         
                         return (
+
                           <motion.div
                             key={`${day}-${period}`}
                             whileHover={{ scale: slot ? 1.03 : 1 }}


### PR DESCRIPTION
#  Student Timetable fix (invalid group selection / race)

- [x] Update `smart-campus-frontend/src/pages/student/Timetable.tsx`:
  - [x] Fix `fetchAvailableGroups` to only auto-select `selectedGroup` when current selection is empty or not present in the newly fetched groups.
  - [x] Guard the timetable-fetching `useEffect` so it only runs when `selectedGroup` is truthy and exists in `availableGroups`.
  - [x] Add request-token / latest-request guard to avoid out-of-order timetable responses overwriting newer data.




closes #123