### PR TITLE
remove api test socket endpoint

### DIFF
--- a/smart-campus-backend/package-lock.json
+++ b/smart-campus-backend/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "joi": "^17.11.0",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^8.0.7",
         "pg": "^8.16.3",
         "socket.io": "^4.8.3",
         "socket.io-client": "^4.8.3",
@@ -5531,6 +5532,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.11",

--- a/smart-campus-backend/package-lock.json
+++ b/smart-campus-backend/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1529,7 +1528,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1915,7 +1913,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2895,7 +2892,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5536,15 +5532,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/nodemon": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
@@ -5887,7 +5874,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/smart-campus-backend/package.json
+++ b/smart-campus-backend/package.json
@@ -39,6 +39,7 @@
     "helmet": "^7.1.0",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^8.0.7",
     "pg": "^8.16.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",

--- a/smart-campus-backend/src/app.js
+++ b/smart-campus-backend/src/app.js
@@ -8,6 +8,7 @@ require('dotenv').config();
 const { testConnection, logger, isDatabaseConnected } = require('./config/db');
 const { errorHandler, notFoundHandler } = require('./middleware/errorHandler');
 const { apiLimiter } = require('./middleware/rateLimiter.middleware');
+const { verifyToken, verifyAdmin } = require('./middleware/auth.middleware');
 const notificationService = require('./services/notification.service');
 
 // Import routes
@@ -151,7 +152,7 @@ app.use('/api/timetable', timetableRoutes);
 app.use('/api/electives', electiveRoutes);
 
 // Test Socket endpoint
-app.get('/api/test-socket', (req, res) => {
+app.get('/api/test-socket', verifyToken, verifyAdmin, (req, res) => {
   const type = req.query.type || 'EVENT_CREATED';
   notificationService.broadcast(type, {
     message: `Test notification for ${type}`,

--- a/smart-campus-frontend/src/contexts/AuthContext.tsx
+++ b/smart-campus-frontend/src/contexts/AuthContext.tsx
@@ -56,7 +56,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setIsLoading(false);
       }
     };
-
     void initializeAuth();
   }, []);
 
@@ -70,7 +69,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setUser(currentUser);
         setToken(COOKIE_AUTH_STATE);
         localStorage.setItem('user', JSON.stringify(currentUser));
-      } catch {
+      } 
+      catch { 
         setUser(null);
         setToken(null);
         localStorage.removeItem('user');


### PR DESCRIPTION
# NSoC '26
## Closes Issue #159 

## Summary
Secures the unauthenticated `/api/test-socket` endpoint in `smart-campus-backend/src/app.js` by requiring authentication and admin authorization before allowing Socket.IO broadcast triggers.

## Changes
- Imported `verifyToken` and `verifyAdmin` from `src/middleware/auth.middleware`.
- Updated route:
  - From: `app.get('/api/test-socket', handler)`
  - To: `app.get('/api/test-socket', verifyToken, verifyAdmin, handler)`

## Why
Previously, anyone could call this endpoint and trigger arbitrary broadcasts to all connected clients. This change prevents unauthorized broadcast abuse.

## Validation
- ✅ `npm run lint` (backend)
- ✅ `JWT_SECRET=test npx jest __tests__/middleware.test.js`
