### PR TITLE
fix : added fix for duplicate sendSuccess call in event controller

### DIFF
--- a/smart-campus-backend/src/components/campus-events/events.controller.js
+++ b/smart-campus-backend/src/components/campus-events/events.controller.js
@@ -91,7 +91,6 @@ await notificationService.notifyRole({
     event: result.rows[0],
   });
 
-  sendSuccess(res, 201, 'Event created successfully', { event: result.rows[0] });
 });
 
 /**


### PR DESCRIPTION
Closes #173.

Summary of What Has Been Done:
Removed the duplicate call to sendSuccess in the event creation endpoint of the campus events controller. This prevents sending a duplicate HTTP success response to the client when a new event is created.

Changes Made:
In smart-campus-backend/src/components/campus-events/events.controller.js, removed the second consecutive sendSuccess invocation in the createEvent controller flow.

Impact it Made:
Ensures a single, consistent API response with a 201 status code when creating an event, preventing client-side response-handling bugs and errors related to multiple headers sent.