### PR TITLE
fix: unify auth/WS base URL via env config

### DIFF
--- a/smart-campus-frontend/.env.example
+++ b/smart-campus-frontend/.env.example
@@ -10,3 +10,6 @@
 # -----------------------------------------------
 # Base URL of the running backend API
 VITE_API_BASE_URL=http://localhost:5000/api
+
+# Optional override for auth/SSO + websocket base URL (defaults to VITE_API_BASE_URL without /api)
+# VITE_AUTH_BASE_URL=http://localhost:5000

--- a/smart-campus-frontend/INTEGRATION_GUIDE.md
+++ b/smart-campus-frontend/INTEGRATION_GUIDE.md
@@ -67,6 +67,8 @@ src/
 Edit `.env` file:
 ```env
 VITE_API_BASE_URL=http://localhost:5000/api
+# Optional override for auth/SSO + websocket base URL
+# VITE_AUTH_BASE_URL=http://localhost:5000
 ```
 
 The axios instance is configured in `src/lib/axios.ts` with automatic token injection.

--- a/smart-campus-frontend/README.md
+++ b/smart-campus-frontend/README.md
@@ -22,6 +22,7 @@ cp .env.example .env
 ```
 
 Set `VITE_API_BASE_URL` in `.env` (default backend URL is `http://localhost:5000/api`).
+Optionally set `VITE_AUTH_BASE_URL` for SSO/websocket base URL if it differs from `VITE_API_BASE_URL` without `/api`.
 
 3. Run development server:
 
@@ -52,4 +53,3 @@ npm run dev
 - Do not commit `.env` files.
 - Keep service-layer changes in `src/services/`.
 - Prefer reusable UI components in `src/components/ui/`.
-

--- a/smart-campus-frontend/src/contexts/NotificationContext.tsx
+++ b/smart-campus-frontend/src/contexts/NotificationContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { toast } from 'sonner';
+import { getBackendBaseUrl } from '@/lib/apiConfig';
 
 interface NotificationContextType {
   socket: Socket | null;
@@ -17,11 +18,9 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     // Connect to the backend WebSocket server
-    const backendUrl = import.meta.env.VITE_API_BASE_URL 
-      ? import.meta.env.VITE_API_BASE_URL.replace('/api', '') 
-      : 'http://localhost:5000';
-      
-    const socketInstance = io(backendUrl, {
+    const backendUrl = getBackendBaseUrl();
+
+    const socketInstance = io(backendUrl || undefined, {
       reconnection: true, // Automatically reconnects
       reconnectionDelay: 1000,
       reconnectionDelayMax: 5000,

--- a/smart-campus-frontend/src/lib/apiConfig.ts
+++ b/smart-campus-frontend/src/lib/apiConfig.ts
@@ -1,0 +1,34 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:5000/api';
+
+const normalizeUrl = (value: string) => value.replace(/\/+$/, '');
+
+const stripApiSuffix = (value: string) => value.replace(/\/api$/i, '');
+
+export const getApiBaseUrl = () => {
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || DEFAULT_API_BASE_URL;
+  return normalizeUrl(apiBaseUrl);
+};
+
+export const getBackendBaseUrl = () => {
+  const explicitBaseUrl = import.meta.env.VITE_AUTH_BASE_URL;
+  if (explicitBaseUrl) {
+    return normalizeUrl(explicitBaseUrl);
+  }
+
+  const apiBaseUrl = getApiBaseUrl();
+  return stripApiSuffix(apiBaseUrl);
+};
+
+export const buildBackendUrl = (path: string) => {
+  const baseUrl = getBackendBaseUrl();
+
+  if (!path) {
+    return baseUrl;
+  }
+
+  if (!baseUrl) {
+    return path.startsWith('/') ? path : `/${path}`;
+  }
+
+  return `${baseUrl}${path.startsWith('/') ? '' : '/'}${path}`;
+};

--- a/smart-campus-frontend/src/lib/axios.ts
+++ b/smart-campus-frontend/src/lib/axios.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosError } from 'axios';
 import { ApiError } from '@/types';
+import { getApiBaseUrl } from '@/lib/apiConfig';
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
+  baseURL: getApiBaseUrl(),
   headers: {
     'Content-Type': 'application/json',
   },
@@ -11,7 +12,7 @@ export const api = axios.create({
 });
 
 const refreshClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
+  baseURL: getApiBaseUrl(),
   withCredentials: true,
   timeout: 10000,
 });

--- a/smart-campus-frontend/src/pages/Auth.tsx
+++ b/smart-campus-frontend/src/pages/Auth.tsx
@@ -11,6 +11,7 @@ import { GraduationCap, CheckCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { RegisterRequest } from '@/services/authService';
 import AuthBackground from '@/components/animations/AuthBackground';
+import { buildBackendUrl } from '@/lib/apiConfig';
 
 
 export default function Auth() {
@@ -278,7 +279,7 @@ export default function Auth() {
 
                       <div className="grid grid-cols-2 gap-4">
                         <Button variant="outline" asChild className="w-full">
-                          <a href="http://localhost:5000/api/auth/sso/google">
+                          <a href={buildBackendUrl('/api/auth/sso/google')}>
                             <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
                               <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
                               <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
@@ -289,7 +290,7 @@ export default function Auth() {
                           </a>
                         </Button>
                         <Button variant="outline" asChild className="w-full">
-                          <a href="http://localhost:5000/api/auth/sso/microsoft">
+                          <a href={buildBackendUrl('/api/auth/sso/microsoft')}>
                             <svg className="mr-2 h-4 w-4" viewBox="0 0 21 21">
                               <path fill="#f25022" d="M1 1h9v9H1z"/>
                               <path fill="#00a4ef" d="M1 11h9v9H1z"/>


### PR DESCRIPTION
# NSoC'26
## Summary
Eliminate hardcoded localhost SSO/WebSocket URLs in the frontend by introducing a single, env-driven source of truth for backend base URLs. This makes staging/production deployments work without code edits and keeps Axios, SSO links, and websocket connections aligned.

## Problem
SSO links were hardcoded to `http://localhost:5000`, and the websocket client built its own backend URL, causing:
- Broken SSO in non-local environments
- Divergent base URL logic across Axios, auth, and notifications

## Solution
Centralize backend URL derivation and reuse it everywhere:
- A new `apiConfig` helper derives API base URL and backend base URL.
- Optional `VITE_AUTH_BASE_URL` allows explicit overrides when backend and API differ.
- Auth SSO links and NotificationContext websocket connection now share the helper.

## Changes
- `smart-campus-frontend/src/lib/apiConfig.ts` (new): `getApiBaseUrl`, `getBackendBaseUrl`, and `buildBackendUrl`.
- `Auth.tsx`: SSO links use `buildBackendUrl`.
- `NotificationContext.tsx`: websocket connects via `getBackendBaseUrl`.
- `.env.example`, frontend README, integration guide: document `VITE_AUTH_BASE_URL` and behavior.

## Acceptance Criteria Coverage
- ✅ No hardcoded localhost URLs in auth/notification logic.
- ✅ SSO works in non-local deployments without code changes.
- ✅ One source of truth for backend base URL (Axios + WebSocket + SSO).

## Related Issue
Closes #186