### PR TITLE
feat: add copy link functionality for event sharing

### DIFF
--- a/smart-campus-frontend/src/pages/student/Events.tsx
+++ b/smart-campus-frontend/src/pages/student/Events.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,7 +30,7 @@ export default function EventsPage() {
     search: '',
     department: '',
     tag: '',
-    upcoming: 'true'
+    upcoming: 'true',
   });
 
   useEffect(() => {
@@ -60,7 +60,7 @@ export default function EventsPage() {
   const loadSavedEvents = async () => {
     try {
       const response = await eventsService.getMySaved();
-      const ids = new Set(response.data?.events?.map((e: Event) => e.id) || []);
+      const ids = new Set(response.data?.events?.map((event: Event) => event.id) || []);
       setSavedEventIds(ids);
     } catch (error: unknown) {
       console.error('Failed to load saved events', error);
@@ -82,15 +82,11 @@ export default function EventsPage() {
           newSet.delete(eventId);
           return newSet;
         });
-        toast({
-          title: 'Event removed from saved',
-        });
+        toast({ title: 'Event removed from saved' });
       } else {
         await eventsService.save(eventId);
         setSavedEventIds(prev => new Set(prev).add(eventId));
-        toast({
-          title: 'Event saved successfully!',
-        });
+        toast({ title: 'Event saved successfully!' });
       }
     } catch (error: unknown) {
       const e = error as { message?: string };
@@ -130,7 +126,7 @@ export default function EventsPage() {
   const handleShareEvent = async (event: ExtendedEvent) => {
     const shareData = {
       title: event.title,
-      text: `📅 ${event.title}\n🕐 ${new Date(event.start_time).toLocaleString()}\n📍 ${event.location}${event.description ? `\n\n${event.description}` : ''}`,
+      text: `Event: ${event.title}\nTime: ${new Date(event.start_time).toLocaleString()}\nLocation: ${event.location}${description}`,
       url: window.location.href,
     };
 
@@ -149,9 +145,7 @@ export default function EventsPage() {
       try {
         const fallbackText = `${shareData.title}\n${shareData.text}\n${shareData.url}`;
         await navigator.clipboard.writeText(fallbackText);
-        toast({
-          title: 'Event details copied to clipboard!',
-        });
+        toast({ title: 'Event details copied to clipboard!' });
       } catch {
         toast({
           variant: 'destructive',
@@ -164,9 +158,7 @@ export default function EventsPage() {
   const handleCopyEventLink = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      toast({
-        title: 'Link copied to clipboard!',
-      });
+      toast({ title: 'Link copied to clipboard!' });
     } catch {
       toast({
         variant: 'destructive',
@@ -216,7 +208,6 @@ export default function EventsPage() {
           <p className="text-muted-foreground">Discover and save upcoming events</p>
         </div>
 
-        {/* Filters Card */}
         <Card className="glass">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -277,7 +268,6 @@ export default function EventsPage() {
           </CardContent>
         </Card>
 
-        {/* Events Grid */}
         {isLoading ? (
           <div className="flex items-center justify-center min-h-[400px]">
             <div className="text-center space-y-4">
@@ -290,9 +280,7 @@ export default function EventsPage() {
             <CardContent className="py-12 text-center">
               <Calendar className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
               <h3 className="text-lg font-semibold mb-2">No Events Found</h3>
-              <p className="text-muted-foreground">
-                Try adjusting your filters to find events
-              </p>
+              <p className="text-muted-foreground">Try adjusting your filters to find events</p>
             </CardContent>
           </Card>
         ) : (
@@ -309,7 +297,6 @@ export default function EventsPage() {
                     <CardTitle className="flex items-start justify-between gap-2">
                       <span className="flex-1">{event.title}</span>
                       <div className="flex items-center gap-2 flex-shrink-0">
-                        {/* Copy Link Button */}
                         <motion.button
                           whileHover={{ scale: 1.1 }}
                           whileTap={{ scale: 0.9 }}
@@ -320,7 +307,6 @@ export default function EventsPage() {
                           <Copy className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
                         </motion.button>
 
-                        {/* Share Button */}
                         <motion.button
                           whileHover={{ scale: 1.1 }}
                           whileTap={{ scale: 0.9 }}
@@ -331,6 +317,7 @@ export default function EventsPage() {
                           <Share2 className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
                         </motion.button>
 
+<<<<<<< HEAD
               return (
                 <motion.div
                   key={event.id}
@@ -387,6 +374,16 @@ export default function EventsPage() {
                               className={`flex-shrink-0 ${!isOnline ? 'opacity-50 cursor-not-allowed' : ''}`}
                               title={savedEventIds.has(event.id) ? 'Remove from saved' : 'Save event'}
                               aria-label={savedEventIds.has(event.id) ? `Unsave ${event.title}` : `Save ${event.title}`}
+=======
+                        <motion.button
+                          whileHover={isOnline ? { scale: 1.1 } : {}}
+                          whileTap={isOnline ? { scale: 0.9 } : {}}
+                          onClick={() => isOnline && handleSaveEvent(event.id)}
+                          disabled={isSavingMap.get(event.id) || !isOnline}
+                          className={`flex-shrink-0 ${!isOnline ? 'opacity-50 cursor-not-allowed' : ''}`}
+                          title={savedEventIds.has(event.id) ? 'Remove from saved' : 'Save event'}
+                          aria-label={savedEventIds.has(event.id) ? `Unsave ${event.title}` : `Save ${event.title}`}
+>>>>>>> 78fdc45 (Fix event link copy button parsing)
                         >
                           <Bookmark
                             className={`h-5 w-5 transition-colors ${
@@ -399,8 +396,14 @@ export default function EventsPage() {
                       </div>
                     </CardTitle>
                   </CardHeader>
+<<<<<<< HEAD
                   <CardContent className="space-y-3">
                     <p className="text-muted-foreground text-sm">{event.description}</p>
+=======
+
+                  <CardContent className="space-y-3 flex-1 flex flex-col">
+                    <p className="text-muted-foreground text-sm flex-1">{event.description}</p>
+>>>>>>> 78fdc45 (Fix event link copy button parsing)
                     <div className="space-y-2 text-sm">
                       <div className="flex items-center gap-2 text-muted-foreground">
                         <Calendar className="h-4 w-4" />
@@ -422,6 +425,24 @@ export default function EventsPage() {
                         </span>
                       </div>
                     </div>
+<<<<<<< HEAD
+=======
+                    {event.club_name && (
+                      <div className="text-xs text-accent font-medium pt-2">By: {event.club_name}</div>
+                    )}
+                    {event.tags && event.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2 pt-2">
+                        {event.tags.map((tag: string, i: number) => (
+                          <span
+                            key={i}
+                            className="px-2 py-1 text-xs rounded-full bg-accent/20 text-accent-foreground"
+                          >
+                            {tag.trim()}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+>>>>>>> 78fdc45 (Fix event link copy button parsing)
                   </CardContent>
                 </div>
 

--- a/smart-campus-frontend/src/pages/student/Events.tsx
+++ b/smart-campus-frontend/src/pages/student/Events.tsx
@@ -5,13 +5,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Calendar, MapPin, Clock, Bookmark, Search, Filter, AlertCircle, Loader, Share2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { Calendar, MapPin, Clock, Bookmark, Search, Filter, AlertCircle, Loader, Share2, Copy } from 'lucide-react';
 import { eventsService, Event } from '@/services/eventService';
 import { useConnectivity } from '@/contexts/ConnectivityContext';
+import { useToast } from '@/components/ui/use-toast';
 
 export default function EventsPage() {
   const { isOnline } = useConnectivity();
+  const { toast } = useToast();
   const [events, setEvents] = useState<Event[]>([]);
   const [savedEventIds, setSavedEventIds] = useState<Set<number>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
@@ -39,7 +40,10 @@ export default function EventsPage() {
       const e = error as { message?: string };
       const errorMsg = e?.message || 'Failed to load events';
       setError(errorMsg);
-      toast.error(errorMsg);
+      toast({
+        variant: 'destructive',
+        title: errorMsg,
+      });
     } finally {
       setIsLoading(false);
     }
@@ -70,15 +74,22 @@ export default function EventsPage() {
           newSet.delete(eventId);
           return newSet;
         });
-        toast.success('Event removed from saved');
+        toast({
+          title: 'Event removed from saved',
+        });
       } else {
         await eventsService.save(eventId);
         setSavedEventIds(prev => new Set(prev).add(eventId));
-        toast.success('Event saved successfully!');
+        toast({
+          title: 'Event saved successfully!',
+        });
       }
     } catch (error: unknown) {
       const e = error as { message?: string };
-      toast.error(e?.message || 'Failed to save event');
+      toast({
+        variant: 'destructive',
+        title: e?.message || 'Failed to save event',
+      });
     } finally {
       setIsSavingMap(new Map(isSavingMap).set(eventId, false));
     }
@@ -97,7 +108,10 @@ export default function EventsPage() {
       } catch (err: unknown) {
         // User cancelled the share — not an error worth toasting
         if (err instanceof Error && err.name !== 'AbortError') {
-          toast.error('Failed to share event');
+          toast({
+            variant: 'destructive',
+            title: 'Failed to share event',
+          });
         }
       }
     } else {
@@ -105,10 +119,29 @@ export default function EventsPage() {
       try {
         const fallbackText = `${shareData.title}\n${shareData.text}\n${shareData.url}`;
         await navigator.clipboard.writeText(fallbackText);
-        toast.success('Event details copied to clipboard!');
+        toast({
+          title: 'Event details copied to clipboard!',
+        });
       } catch {
-        toast.error('Unable to share or copy event details');
+        toast({
+          variant: 'destructive',
+          title: 'Unable to share or copy event details',
+        });
       }
+    }
+  };
+
+  const handleCopyEventLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast({
+        title: 'Link copied to clipboard!',
+      });
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: 'Unable to copy link',
+      });
     }
   };
 
@@ -246,6 +279,17 @@ export default function EventsPage() {
                     <CardTitle className="flex items-start justify-between gap-2">
                       <span className="flex-1">{event.title}</span>
                       <div className="flex items-center gap-2 flex-shrink-0">
+                        {/* Copy Link Button */}
+                        <motion.button
+                          whileHover={{ scale: 1.1 }}
+                          whileTap={{ scale: 0.9 }}
+                          onClick={handleCopyEventLink}
+                          title="Copy link"
+                          aria-label={`Copy link for ${event.title}`}
+                        >
+                          <Copy className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
+                        </motion.button>
+
                         {/* Share Button */}
                         <motion.button
                           whileHover={{ scale: 1.1 }}

--- a/smart-campus-frontend/src/pages/student/Events.tsx
+++ b/smart-campus-frontend/src/pages/student/Events.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Calendar, MapPin, Clock, Bookmark, Search, Filter, AlertCircle, Loader, Share2, Copy } from 'lucide-react';
+import { Calendar, MapPin, Clock, Bookmark, Search, Filter, AlertCircle, Loader, Share2, Copy, CheckCircle, Users } from 'lucide-react';
 import { eventsService, Event } from '@/services/eventService';
 import { useConnectivity } from '@/contexts/ConnectivityContext';
 import { useToast } from '@/components/ui/use-toast';
@@ -126,7 +126,7 @@ export default function EventsPage() {
   const handleShareEvent = async (event: ExtendedEvent) => {
     const shareData = {
       title: event.title,
-      text: `Event: ${event.title}\nTime: ${new Date(event.start_time).toLocaleString()}\nLocation: ${event.location}${description}`,
+      text: `Event: ${event.title}\nTime: ${new Date(event.start_time).toLocaleString()}\nLocation: ${event.location}\n${event.description}`,
       url: window.location.href,
     };
 
@@ -285,39 +285,13 @@ export default function EventsPage() {
           </Card>
         ) : (
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {events.map((event: Event, index: number) => (
-              <motion.div
-                key={event.id}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-              >
-                <Card className="glass glow-accent-hover h-full flex flex-col">
-                  <CardHeader>
-                    <CardTitle className="flex items-start justify-between gap-2">
-                      <span className="flex-1">{event.title}</span>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        <motion.button
-                          whileHover={{ scale: 1.1 }}
-                          whileTap={{ scale: 0.9 }}
-                          onClick={handleCopyEventLink}
-                          title="Copy link"
-                          aria-label={`Copy link for ${event.title}`}
-                        >
-                          <Copy className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
-                        </motion.button>
+            {events.map((event: Event, index: number) => {
+              const extendedEvent = event as ExtendedEvent;
+              const userStatus = extendedEvent.rsvp_status;
+              const maxCapacity = extendedEvent.max_capacity ?? 0;
+              const currentConfirmed = extendedEvent.current_confirmed ?? 0;
+              const isFull = maxCapacity > 0 && currentConfirmed >= maxCapacity;
 
-                        <motion.button
-                          whileHover={{ scale: 1.1 }}
-                          whileTap={{ scale: 0.9 }}
-                          onClick={() => handleShareEvent(event)}
-                          title="Share event"
-                          aria-label={`Share ${event.title}`}
-                        >
-                          <Share2 className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
-                        </motion.button>
-
-<<<<<<< HEAD
               return (
                 <motion.div
                   key={event.id}
@@ -354,6 +328,16 @@ export default function EventsPage() {
                           </div>
                           
                           <div className="flex items-center gap-2 flex-shrink-0">
+                            <motion.button
+                              whileHover={{ scale: 1.1 }}
+                              whileTap={{ scale: 0.9 }}
+                              onClick={handleCopyEventLink}
+                              title="Copy link"
+                              aria-label={`Copy link for ${event.title}`}
+                            >
+                              <Copy className="h-5 w-5 text-muted-foreground hover:text-primary transition-colors" />
+                            </motion.button>
+
                             {/* Share Button */}
                             <motion.button
                               whileHover={{ scale: 1.1 }}
@@ -374,16 +358,6 @@ export default function EventsPage() {
                               className={`flex-shrink-0 ${!isOnline ? 'opacity-50 cursor-not-allowed' : ''}`}
                               title={savedEventIds.has(event.id) ? 'Remove from saved' : 'Save event'}
                               aria-label={savedEventIds.has(event.id) ? `Unsave ${event.title}` : `Save ${event.title}`}
-=======
-                        <motion.button
-                          whileHover={isOnline ? { scale: 1.1 } : {}}
-                          whileTap={isOnline ? { scale: 0.9 } : {}}
-                          onClick={() => isOnline && handleSaveEvent(event.id)}
-                          disabled={isSavingMap.get(event.id) || !isOnline}
-                          className={`flex-shrink-0 ${!isOnline ? 'opacity-50 cursor-not-allowed' : ''}`}
-                          title={savedEventIds.has(event.id) ? 'Remove from saved' : 'Save event'}
-                          aria-label={savedEventIds.has(event.id) ? `Unsave ${event.title}` : `Save ${event.title}`}
->>>>>>> 78fdc45 (Fix event link copy button parsing)
                         >
                           <Bookmark
                             className={`h-5 w-5 transition-colors ${
@@ -396,14 +370,8 @@ export default function EventsPage() {
                       </div>
                     </CardTitle>
                   </CardHeader>
-<<<<<<< HEAD
-                  <CardContent className="space-y-3">
-                    <p className="text-muted-foreground text-sm">{event.description}</p>
-=======
-
                   <CardContent className="space-y-3 flex-1 flex flex-col">
                     <p className="text-muted-foreground text-sm flex-1">{event.description}</p>
->>>>>>> 78fdc45 (Fix event link copy button parsing)
                     <div className="space-y-2 text-sm">
                       <div className="flex items-center gap-2 text-muted-foreground">
                         <Calendar className="h-4 w-4" />
@@ -425,8 +393,6 @@ export default function EventsPage() {
                         </span>
                       </div>
                     </div>
-<<<<<<< HEAD
-=======
                     {event.club_name && (
                       <div className="text-xs text-accent font-medium pt-2">By: {event.club_name}</div>
                     )}
@@ -442,7 +408,6 @@ export default function EventsPage() {
                         ))}
                       </div>
                     )}
->>>>>>> 78fdc45 (Fix event link copy button parsing)
                   </CardContent>
                 </div>
 


### PR DESCRIPTION
# Summary
Added a Copy Link button to student event cards so users can quickly copy the current event page URL and share it with others.
# Changes
- Added a Copy icon button to the event card action row in `smart-campus-frontend/src/pages/student/Events.tsx`.
- Implemented clipboard handling with navigator.clipboard.writeText(window.location.href).
- Added a success toast using the existing use-toast hook with the message Link copied to clipboard!.
- Kept the existing share and bookmark actions intact.