### PR TITLE
feat: integrate MSW into Vitest for frontend API mocking

### DIFF
--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -86,6 +86,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
         "lovable-tagger": "^1.1.11",
+        "msw": "^2.14.6",
         "postcss": "^8.5.6",
         "prettier": "^3.8.3",
         "tailwindcss": "^3.4.17",
@@ -167,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -319,6 +319,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -363,6 +364,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1056,6 +1058,93 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1139,6 +1228,31 @@
         "three": ">= 0.159.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1173,6 +1287,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2686,6 +2825,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -3372,7 +3512,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3392,7 +3531,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3401,8 +3539,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -3460,8 +3597,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3566,6 +3702,7 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3587,6 +3724,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3598,6 +3736,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3611,10 +3750,27 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
       "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/three": {
@@ -3622,6 +3778,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
       "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3684,6 +3841,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -4022,6 +4180,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4327,6 +4486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4574,6 +4734,94 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4644,6 +4892,20 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4866,6 +5128,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4930,7 +5193,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5015,7 +5277,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5188,7 +5451,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5213,6 +5476,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5467,6 +5731,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -5678,6 +5969,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -5832,6 +6133,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
+      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5879,6 +6190,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hls.js": {
@@ -5969,6 +6291,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -6138,6 +6461,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6234,6 +6564,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -7137,7 +7468,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7311,6 +7641,62 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -7435,6 +7821,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7539,6 +7932,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -7609,6 +8009,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7770,7 +8171,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7785,7 +8185,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7795,7 +8194,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7807,8 +8205,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -7880,6 +8277,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7918,6 +8316,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7931,6 +8330,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8235,6 +8635,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8287,6 +8697,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -8417,6 +8834,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8582,10 +9006,27 @@
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -8799,6 +9240,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -8814,6 +9268,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8880,7 +9335,8 @@
       "version": "0.160.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
       "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -9007,9 +9463,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -9135,12 +9591,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9179,6 +9652,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -9328,6 +9811,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9765,6 +10249,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
@@ -9778,6 +10272,80 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/smart-campus-frontend/package.json
+++ b/smart-campus-frontend/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "smart-campus-frontend",
   "private": true,
@@ -94,6 +93,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "lovable-tagger": "^1.1.11",
+    "msw": "^2.14.6",
     "postcss": "^8.5.6",
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.17",

--- a/smart-campus-frontend/src/test/mocks/handlers.ts
+++ b/smart-campus-frontend/src/test/mocks/handlers.ts
@@ -1,0 +1,429 @@
+/**
+ * MSW Request Handlers
+ *
+ * This file defines all mock API routes for the Smart Campus frontend test suite.
+ * Each handler intercepts matching HTTP requests at the network level and returns
+ * controlled, predictable responses — no backend needed.
+ *
+ * Base URL mirrors src/lib/apiConfig.ts → http://localhost:5000/api
+ *
+ * Pattern: http.[method]('http://localhost:5000/api/<route>', resolver)
+ */
+
+import { http, HttpResponse } from 'msw';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared fixture data — reusable across handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const mockStudentUser = {
+  id: 1,
+  full_name: 'Test Student',
+  email: 'student@campus.edu',
+  role: 'student' as const,
+  department: 'Computer Science',
+  cgpa: 8.5,
+  semester: 5,
+  is_active: true,
+  created_at: '2024-01-15T00:00:00.000Z',
+};
+
+export const mockAdminUser = {
+  id: 2,
+  full_name: 'Test Admin',
+  email: 'admin@campus.edu',
+  role: 'admin' as const,
+  department: 'Administration',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00.000Z',
+};
+
+export const mockTimetableSlots = [
+  {
+    id: 'slot-1',
+    day_of_week: 'Monday',
+    period_number: 1,
+    subject: { subject_code: 'CS501', subject_name: 'Algorithms', course_type: 'Theory' },
+    teacher: { teacher_code: 'T001', full_name: 'Dr. Smith' },
+    room: { room_code: 'R101', room_name: 'Lab 101' },
+    academic_year: '2024-25',
+    semester_type: 'odd',
+  },
+  {
+    id: 'slot-2',
+    day_of_week: 'Tuesday',
+    period_number: 2,
+    subject: { subject_code: 'CS502', subject_name: 'Operating Systems', course_type: 'Theory' },
+    teacher: { teacher_code: 'T002', full_name: 'Dr. Johnson' },
+    room: { room_code: 'R102', room_name: 'Classroom 102' },
+    academic_year: '2024-25',
+    semester_type: 'odd',
+  },
+];
+
+export const mockEvents = [
+  {
+    id: 1,
+    title: 'Tech Fest 2026',
+    description: 'Annual technology festival',
+    location: 'Main Auditorium',
+    start_time: '2026-07-10T09:00:00.000Z',
+    end_time: '2026-07-10T18:00:00.000Z',
+    club_name: 'Tech Club',
+    is_featured: true,
+    tags: ['tech', 'annual'],
+  },
+  {
+    id: 2,
+    title: 'Cultural Night',
+    description: 'Evening of cultural performances',
+    location: 'Open Air Theatre',
+    start_time: '2026-07-15T18:00:00.000Z',
+    end_time: '2026-07-15T22:00:00.000Z',
+    club_name: 'Cultural Club',
+    is_featured: false,
+    tags: ['culture'],
+  },
+];
+
+export const mockElectives = [
+  {
+    id: 1,
+    subject_name: 'Machine Learning',
+    description: 'Introduction to ML algorithms and applications',
+    max_students: 60,
+    department: 'Computer Science',
+    semester: 7,
+    current_students: 42,
+    teacher_name: 'Dr. Alan Turing',
+  },
+  {
+    id: 2,
+    subject_name: 'Cloud Computing',
+    description: 'Modern cloud infrastructure and DevOps',
+    max_students: 50,
+    department: 'Computer Science',
+    semester: 7,
+    current_students: 35,
+    teacher_name: 'Dr. Ada Lovelace',
+  },
+];
+
+export const mockNotifications = [
+  {
+    id: 1,
+    message: 'Your timetable has been updated',
+    type: 'TIMETABLE_UPDATED',
+    is_read: false,
+    created_at: '2026-06-04T10:00:00.000Z',
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AUTH HANDLERS  (/api/auth/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const authHandlers = [
+  /**
+   * GET /api/auth/profile
+   * Returns the currently authenticated user's profile.
+   * Used by AuthContext on app load to restore session.
+   */
+  http.get('http://localhost:5000/api/auth/profile', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Profile fetched successfully',
+      data: { user: mockStudentUser },
+    });
+  }),
+
+  /**
+   * POST /api/auth/login
+   * Validates credentials and returns user + sets auth cookie.
+   */
+  http.post('http://localhost:5000/api/auth/login', async ({ request }) => {
+    const body = await request.json() as { email: string; password: string };
+
+    if (body.email === 'admin@campus.edu') {
+      return HttpResponse.json({
+        success: true,
+        message: 'Login successful',
+        data: { user: mockAdminUser },
+      });
+    }
+
+    return HttpResponse.json({
+      success: true,
+      message: 'Login successful',
+      data: { user: mockStudentUser },
+    });
+  }),
+
+  /**
+   * POST /api/auth/register
+   * Creates a new user account.
+   */
+  http.post('http://localhost:5000/api/auth/register', async ({ request }) => {
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      success: true,
+      message: 'Registration successful',
+      data: {
+        user: {
+          ...mockStudentUser,
+          full_name: body.full_name as string,
+          email: body.email as string,
+          role: body.role as string,
+        },
+      },
+    });
+  }),
+
+  /**
+   * POST /api/auth/logout
+   * Clears the auth session server-side.
+   */
+  http.post('http://localhost:5000/api/auth/logout', () => {
+    return HttpResponse.json({ success: true, message: 'Logged out successfully' });
+  }),
+
+  /**
+   * POST /api/auth/refresh
+   * Refreshes the auth token using the refresh cookie.
+   */
+  http.post('http://localhost:5000/api/auth/refresh', () => {
+    return HttpResponse.json({ success: true, message: 'Token refreshed' });
+  }),
+
+  /**
+   * PUT /api/auth/profile
+   * Updates the authenticated user's profile data.
+   */
+  http.put('http://localhost:5000/api/auth/profile', async ({ request }) => {
+    const body = await request.json() as Partial<typeof mockStudentUser>;
+    return HttpResponse.json({
+      success: true,
+      message: 'Profile updated successfully',
+      data: { user: { ...mockStudentUser, ...body } },
+    });
+  }),
+
+  /**
+   * POST /api/auth/change-password
+   * Allows authenticated users to change their password.
+   */
+  http.post('http://localhost:5000/api/auth/change-password', () => {
+    return HttpResponse.json({ success: true, message: 'Password changed successfully' });
+  }),
+
+  /**
+   * POST /api/auth/forgot-password
+   */
+  http.post('http://localhost:5000/api/auth/forgot-password', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Password reset email sent',
+      data: { message: 'Check your email for reset instructions' },
+    });
+  }),
+
+  /**
+   * POST /api/auth/reset-password
+   */
+  http.post('http://localhost:5000/api/auth/reset-password', () => {
+    return HttpResponse.json({ success: true, message: 'Password reset successful' });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TIMETABLE HANDLERS  (/api/timetable/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const timetableHandlers = [
+  /**
+   * GET /api/timetable/group/:groupId
+   * Returns a group's weekly timetable schedule.
+   */
+  http.get('http://localhost:5000/api/timetable/group/:groupId', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Timetable fetched successfully',
+      data: { slots: mockTimetableSlots },
+    });
+  }),
+
+  /**
+   * GET /api/timetable/teachers
+   */
+  http.get('http://localhost:5000/api/timetable/teachers', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Teachers fetched successfully',
+      data: {
+        teachers: [
+          { id: 't-1', teacher_code: 'T001', full_name: 'Dr. Smith', department: 'CS', email: 'smith@campus.edu', phone: '1234567890', is_active: true },
+          { id: 't-2', teacher_code: 'T002', full_name: 'Dr. Johnson', department: 'CS', email: 'johnson@campus.edu', phone: '0987654321', is_active: true },
+        ],
+        pagination: { total: 2, page: 1, limit: 20 },
+      },
+    });
+  }),
+
+  /**
+   * GET /api/timetable/subjects
+   */
+  http.get('http://localhost:5000/api/timetable/subjects', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Subjects fetched successfully',
+      data: {
+        subjects: [
+          { id: 's-1', subject_code: 'CS501', subject_name: 'Algorithms', hours_per_week: 4, course_type: 'Theory', department: 'CS', semester: 5, is_active: true },
+        ],
+        pagination: { total: 1, page: 1, limit: 20 },
+      },
+    });
+  }),
+
+  /**
+   * GET /api/timetable/rooms
+   */
+  http.get('http://localhost:5000/api/timetable/rooms', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Rooms fetched successfully',
+      data: {
+        rooms: [
+          { id: 'r-1', room_code: 'R101', room_name: 'Lab 101', capacity: 60, room_type: 'Lab', is_active: true },
+        ],
+        pagination: { total: 1, page: 1, limit: 20 },
+      },
+    });
+  }),
+
+  /**
+   * GET /api/timetable/groups
+   */
+  http.get('http://localhost:5000/api/timetable/groups', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Groups fetched successfully',
+      data: {
+        groups: [
+          { id: 'g-1', group_code: 'CS5A', group_name: 'CS Semester 5 - A', strength: 60, department: 'CS', semester: 5, academic_year: '2024-25', is_active: true },
+        ],
+        pagination: { total: 1, page: 1, limit: 20 },
+      },
+    });
+  }),
+
+  /**
+   * GET /api/timetable/config
+   */
+  http.get('http://localhost:5000/api/timetable/config', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Config fetched successfully',
+      data: { teachers: [], subjects: [], rooms: [], groups: [] },
+    });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EVENTS HANDLERS  (/api/events/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const eventsHandlers = [
+  /**
+   * GET /api/events
+   */
+  http.get('http://localhost:5000/api/events', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Events fetched successfully',
+      data: { events: mockEvents, total: mockEvents.length },
+    });
+  }),
+
+  /**
+   * GET /api/events/:id
+   */
+  http.get('http://localhost:5000/api/events/:id', ({ params }) => {
+    const event = mockEvents.find((e) => e.id === Number(params.id));
+    if (!event) {
+      return HttpResponse.json({ success: false, message: 'Event not found' }, { status: 404 });
+    }
+    return HttpResponse.json({ success: true, message: 'Event fetched', data: { event } });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ELECTIVES HANDLERS  (/api/electives/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const electivesHandlers = [
+  /**
+   * GET /api/electives
+   */
+  http.get('http://localhost:5000/api/electives', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Electives fetched successfully',
+      data: { electives: mockElectives },
+    });
+  }),
+
+  /**
+   * POST /api/electives/:id/enroll
+   */
+  http.post('http://localhost:5000/api/electives/:id/enroll', () => {
+    return HttpResponse.json({ success: true, message: 'Enrolled successfully' });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NOTIFICATIONS HANDLERS  (/api/notifications/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const notificationsHandlers = [
+  /**
+   * GET /api/notifications
+   */
+  http.get('http://localhost:5000/api/notifications', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Notifications fetched',
+      data: { notifications: mockNotifications },
+    });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEARCH HANDLERS  (/api/search/*)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const searchHandlers = [
+  /**
+   * GET /api/search
+   */
+  http.get('http://localhost:5000/api/search', () => {
+    return HttpResponse.json({
+      success: true,
+      message: 'Search results',
+      data: { results: [] },
+    });
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COMBINED EXPORT — consumed by server.ts
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const handlers = [
+  ...authHandlers,
+  ...timetableHandlers,
+  ...eventsHandlers,
+  ...electivesHandlers,
+  ...notificationsHandlers,
+  ...searchHandlers,
+];

--- a/smart-campus-frontend/src/test/mocks/server.ts
+++ b/smart-campus-frontend/src/test/mocks/server.ts
@@ -1,0 +1,18 @@
+/**
+ * MSW Node Server
+ *
+ * Creates the MSW server instance for use in Vitest (Node/jsdom environment).
+ * Uses `setupServer` from `msw/node` — NOT the browser service worker.
+ *
+ * Usage: imported by src/test/setup.ts which wires it into Vitest lifecycle hooks.
+ * Individual tests can call `server.use(...)` to override handlers per-test.
+ */
+
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+/**
+ * The MSW server pre-loaded with all default request handlers.
+ * Lifecycle management (listen / reset / close) is handled in setup.ts.
+ */
+export const server = setupServer(...handlers);

--- a/smart-campus-frontend/src/test/protected-route.test.tsx
+++ b/smart-campus-frontend/src/test/protected-route.test.tsx
@@ -1,247 +1,250 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { PERMISSIONS } from '@/utils/permissions';
 import { User } from '@/types';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import { mockStudentUser, mockAdminUser } from './mocks/handlers';
 
-// Mock the authService
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
 
-vi.mock('@/services/authService', () => ({
-  authService: {
-    login: vi.fn(),
-    register: vi.fn(),
-    getProfile: vi.fn().mockRejectedValue(new Error('Unauthorized')),
-    logout: vi.fn(),
-    updateProfile: vi.fn(),
-    changePassword: vi.fn(),
-  },
-  RegisterRequest: {},
-}));
-
-// Mock the findRouteByPath function to avoid routing complexity in tests
-vi.mock('@/config/routes', () => ({
-  findRouteByPath: vi.fn(() => undefined),
-  getNavigationRoutes: vi.fn(() => []),
-  getAccessibleRoutes: vi.fn(() => []),
-  isPublicRoute: vi.fn(() => false),
-}));
-
-interface TestAuthProviderProps {
-  user: User | null;
-  children: React.ReactNode;
-}
-
-// Custom AuthProvider for testing
-const TestAuthProvider = ({ user, children }: TestAuthProviderProps) => {
-  const mockAuthContext = {
-    user,
-    token: user ? 'test-token' : null,
-    login: vi.fn(),
-    register: vi.fn(),
-    logout: vi.fn(),
-    updateProfile: vi.fn(),
-    changePassword: vi.fn(),
-    isAuthenticated: !!user,
-    isAdmin: user?.role === 'admin',
-    isStudent: user?.role === 'student',
-    isLoading: false,
-    hasPermission: vi.fn((permission: string) => {
-      if (!user) return false;
-      if (user.role === 'admin') return true;
-      if (user.role === 'student') {
-        return ![
-          PERMISSIONS.VIEW_ADMIN_DASHBOARD,
-          PERMISSIONS.CREATE_USER,
-          PERMISSIONS.UPDATE_USER,
-          PERMISSIONS.DELETE_USER,
-        ].includes(permission);
-      }
-      return false;
-    }),
-    hasAllPermissions: vi.fn((permissions: string[]) => {
-      return permissions.every(p => mockAuthContext.hasPermission(p));
-    }),
-    hasAnyPermission: vi.fn((permissions: string[]) => {
-      return permissions.some(p => mockAuthContext.hasPermission(p));
-    }),
-  };
-
-  return (
-    <AuthProvider>
-      {/* Since we can't easily override the context, this is a simplified test setup */}
-      {children}
-    </AuthProvider>
+/**
+ * Wraps a component with the full provider tree ProtectedRoute requires:
+ *   BrowserRouter  (for <Navigate> / routing)
+ *   AuthProvider   (for useAuth — calls /api/auth/profile via MSW on mount)
+ *
+ * MSW intercepts AuthProvider's getProfile() call, so no real server needed.
+ */
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <BrowserRouter>
+      <AuthProvider>{ui}</AuthProvider>
+    </BrowserRouter>,
   );
-};
 
-describe('ProtectedRoute', () => {
-  describe('Authentication Checks', () => {
-    it('should redirect unauthenticated users to /auth', () => {
-      render(
-        <BrowserRouter>
-          <AuthProvider>
-            <ProtectedRoute>
-              <div>Protected Content</div>
-            </ProtectedRoute>
-          </AuthProvider>
-        </BrowserRouter>
-      );
+// ─────────────────────────────────────────────────────────────────────────────
+// Authentication Gate Tests
+// ─────────────────────────────────────────────────────────────────────────────
 
+describe('ProtectedRoute — Authentication Gate', () => {
+  it('does not render protected content when user is unauthenticated', async () => {
+    // Override: profile endpoint returns 401 → AuthProvider sets user = null
+    // → ProtectedRoute redirects to /auth instead of rendering children
+    server.use(
+      http.get('http://localhost:5000/api/auth/profile', () => {
+        return HttpResponse.json(
+          { success: false, message: 'Unauthorized' },
+          { status: 401 },
+        );
+      }),
+    );
+
+    renderWithProviders(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    // Protected content must never appear for unauthenticated users
+    await waitFor(() => {
       expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
     });
   });
 
-  describe('Legacy adminOnly Prop', () => {
-    it('should accept adminOnly prop for backward compatibility', () => {
-      const props = {
-        children: <div>Admin Content</div>,
-        adminOnly: true,
-      };
-
-      expect(props.adminOnly).toBe(true);
-    });
+  it('mock student profile resolves correctly from MSW handler', async () => {
+    // Default handler in handlers.ts returns mockStudentUser — verify shape
+    expect(mockStudentUser.role).toBe('student');
+    expect(mockStudentUser.email).toBe('student@campus.edu');
+    expect(mockStudentUser.is_active).toBe(true);
   });
 
-  describe('Permission Props', () => {
-    it('should accept requiredPermissions prop', () => {
-      const props = {
-        children: <div>Protected Content</div>,
-        requiredPermissions: [PERMISSIONS.VIEW_ADMIN_DASHBOARD],
-      };
-
-      expect(props.requiredPermissions).toBeDefined();
-      expect(props.requiredPermissions?.[0]).toBe(PERMISSIONS.VIEW_ADMIN_DASHBOARD);
-    });
-
-    it('should accept requiredAnyPermissions prop', () => {
-      const props = {
-        children: <div>Protected Content</div>,
-        requiredAnyPermissions: [
-          PERMISSIONS.VIEW_ADMIN_DASHBOARD,
-          PERMISSIONS.VIEW_STUDENT_DASHBOARD,
-        ],
-      };
-
-      expect(props.requiredAnyPermissions).toBeDefined();
-      expect(props.requiredAnyPermissions?.length).toBe(2);
-    });
-  });
-
-  describe('Permission Validation', () => {
-    it('should render children if user has required permission', () => {
-      const testPermissions = [PERMISSIONS.VIEW_STUDENT_DASHBOARD];
-
-      expect(testPermissions).toContain(PERMISSIONS.VIEW_STUDENT_DASHBOARD);
-    });
-  });
-
-  describe('Role-based Access', () => {
-    it('should recognize admin role', () => {
-      const adminUser: User = {
-        id: 1,
-        full_name: 'Admin User',
-        email: 'admin@test.com',
-        role: 'admin',
-        is_active: true,
-        created_at: '2024-01-01',
-      };
-
-      expect(adminUser.role).toBe('admin');
-    });
-
-    it('should recognize student role', () => {
-      const studentUser: User = {
-        id: 2,
-        full_name: 'Student User',
-        email: 'student@test.com',
-        role: 'student',
-        is_active: true,
-        created_at: '2024-01-01',
-      };
-
-      expect(studentUser.role).toBe('student');
-    });
-  });
-
-  describe('Navigation on Unauthorized Access', () => {
-    it('should redirect to /unauthorized on permission denial', () => {
-      const unauthorizedPath = '/unauthorized';
-      expect(unauthorizedPath).toBe('/unauthorized');
-    });
-
-    it('should redirect to /unauthorized when role is not allowed', () => {
-      const allowedRoles = ['admin'];
-      const userRole = 'student';
-
-      expect(allowedRoles.includes(userRole)).toBe(false);
-    });
+  it('mock admin profile resolves correctly from MSW handler', async () => {
+    expect(mockAdminUser.role).toBe('admin');
+    expect(mockAdminUser.email).toBe('admin@campus.edu');
   });
 });
 
-describe('ProtectedRoute Integration Tests', () => {
-  describe('Route Access Control', () => {
-    it('admin routes should be inaccessible to students', () => {
-      const studentPermissions = [
-        PERMISSIONS.VIEW_STUDENT_DASHBOARD,
-        PERMISSIONS.VIEW_TIMETABLE,
-      ];
-      const adminRoute = PERMISSIONS.VIEW_ADMIN_DASHBOARD;
+// ─────────────────────────────────────────────────────────────────────────────
+// MSW Network-Level Interception Tests
+// ─────────────────────────────────────────────────────────────────────────────
 
-      expect(studentPermissions.includes(adminRoute)).toBe(false);
-    });
+describe('ProtectedRoute — MSW Route Interception', () => {
+  it('MSW intercepts /api/auth/profile and returns mock student data', async () => {
+    // Directly verify that MSW is intercepting — fetch the endpoint as
+    // any service function would, and assert the mock response is returned.
+    const response = await fetch('http://localhost:5000/api/auth/profile');
+    const json = await response.json();
 
-    it('student routes should be accessible to students', () => {
-      const studentPermissions = [
-        PERMISSIONS.VIEW_STUDENT_DASHBOARD,
-        PERMISSIONS.VIEW_TIMETABLE,
-        PERMISSIONS.VIEW_EVENTS,
-      ];
-
-      expect(studentPermissions).toContain(PERMISSIONS.VIEW_STUDENT_DASHBOARD);
-      expect(studentPermissions).toContain(PERMISSIONS.VIEW_TIMETABLE);
-    });
-
-    it('admin should have access to all routes', () => {
-      const adminRole = 'admin';
-      const allRoutes = Object.values(PERMISSIONS);
-
-      expect(allRoutes.length).toBeGreaterThan(0);
-    });
+    expect(response.ok).toBe(true);
+    expect(json.success).toBe(true);
+    expect(json.data.user.role).toBe('student');
+    expect(json.data.user.email).toBe('student@campus.edu');
   });
 
-  describe('Direct URL Access Prevention', () => {
-    it('should block direct URL access to admin routes for students', () => {
-      const studentRole = 'student';
-      const adminPath = '/admin/dashboard';
+  it('MSW intercepts /api/timetable/group/:groupId and returns timetable slots', async () => {
+    const response = await fetch('http://localhost:5000/api/timetable/group/g-1');
+    const json = await response.json();
 
-      const hasPermission = studentRole === 'admin' || false;
-      expect(hasPermission).toBe(false);
-    });
-
-    it('should block direct URL access to student routes for admins (if restricted)', () => {
-      const restrictedPath = '/student/dashboard';
-      const allowedRoles = ['student', 'admin'];
-
-      expect(allowedRoles).toContain('admin');
-    });
+    expect(response.ok).toBe(true);
+    expect(json.success).toBe(true);
+    expect(Array.isArray(json.data.slots)).toBe(true);
+    expect(json.data.slots.length).toBeGreaterThan(0);
+    expect(json.data.slots[0]).toHaveProperty('day_of_week');
+    expect(json.data.slots[0]).toHaveProperty('subject');
   });
 
-  describe('Role Switching', () => {
-    it('should update accessible routes when user role changes', () => {
-      let userRole = 'student';
-      let accessibleRoutes = [
+  it('MSW intercepts /api/events and returns event list', async () => {
+    const response = await fetch('http://localhost:5000/api/events');
+    const json = await response.json();
+
+    expect(response.ok).toBe(true);
+    expect(json.success).toBe(true);
+    expect(Array.isArray(json.data.events)).toBe(true);
+    expect(json.data.events[0].title).toBe('Tech Fest 2026');
+  });
+
+  it('MSW intercepts /api/electives and returns elective list', async () => {
+    const response = await fetch('http://localhost:5000/api/electives');
+    const json = await response.json();
+
+    expect(json.success).toBe(true);
+    expect(json.data.electives[0].subject_name).toBe('Machine Learning');
+  });
+
+  it('per-test handler override returns 401 without affecting other tests', async () => {
+    server.use(
+      http.get('http://localhost:5000/api/auth/profile', () => {
+        return HttpResponse.json(
+          { success: false, message: 'Unauthorized' },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const response = await fetch('http://localhost:5000/api/auth/profile');
+    expect(response.status).toBe(401);
+
+    const json = await response.json();
+    expect(json.success).toBe(false);
+    expect(json.message).toBe('Unauthorized');
+  });
+
+  it('handler reset restores default profile after per-test override', async () => {
+    // afterEach → server.resetHandlers() ran before this test
+    // So the default handler is back — should return 200 + student user
+    const response = await fetch('http://localhost:5000/api/auth/profile');
+    expect(response.ok).toBe(true);
+
+    const json = await response.json();
+    expect(json.data.user.role).toBe('student');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Permission & Role Tests (no network — pure logic)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ProtectedRoute — Permission & Role Logic', () => {
+  it('accepts adminOnly prop for backward compatibility', () => {
+    const props = { children: <div>Admin Content</div>, adminOnly: true };
+    expect(props.adminOnly).toBe(true);
+  });
+
+  it('accepts requiredPermissions prop', () => {
+    const props = {
+      children: <div>Protected Content</div>,
+      requiredPermissions: [PERMISSIONS.VIEW_ADMIN_DASHBOARD],
+    };
+    expect(props.requiredPermissions).toBeDefined();
+    expect(props.requiredPermissions[0]).toBe(PERMISSIONS.VIEW_ADMIN_DASHBOARD);
+  });
+
+  it('accepts requiredAnyPermissions prop', () => {
+    const props = {
+      children: <div>Protected Content</div>,
+      requiredAnyPermissions: [
+        PERMISSIONS.VIEW_ADMIN_DASHBOARD,
         PERMISSIONS.VIEW_STUDENT_DASHBOARD,
-        PERMISSIONS.VIEW_TIMETABLE,
-      ];
+      ],
+    };
+    expect(props.requiredAnyPermissions).toBeDefined();
+    expect(props.requiredAnyPermissions.length).toBe(2);
+  });
 
-      expect(accessibleRoutes).toContain(PERMISSIONS.VIEW_STUDENT_DASHBOARD);
+  it('student does not have admin dashboard permission', () => {
+    const studentPermissions = [
+      PERMISSIONS.VIEW_STUDENT_DASHBOARD,
+      PERMISSIONS.VIEW_TIMETABLE,
+    ];
+    expect(studentPermissions.includes(PERMISSIONS.VIEW_ADMIN_DASHBOARD)).toBe(false);
+  });
 
-      userRole = 'admin';
-      accessibleRoutes = Object.values(PERMISSIONS);
+  it('student has access to student-level routes', () => {
+    const studentPermissions = [
+      PERMISSIONS.VIEW_STUDENT_DASHBOARD,
+      PERMISSIONS.VIEW_TIMETABLE,
+      PERMISSIONS.VIEW_EVENTS,
+    ];
+    expect(studentPermissions).toContain(PERMISSIONS.VIEW_STUDENT_DASHBOARD);
+    expect(studentPermissions).toContain(PERMISSIONS.VIEW_TIMETABLE);
+  });
 
-      expect(accessibleRoutes.length).toBeGreaterThan(5);
-    });
+  it('admin role grants access to all permission keys', () => {
+    const allRoutes = Object.values(PERMISSIONS);
+    expect(allRoutes.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Role-Based Access Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ProtectedRoute — Role Recognition', () => {
+  it('recognises admin role from User object', () => {
+    const adminUser: User = {
+      id: 1,
+      full_name: 'Admin User',
+      email: 'admin@test.com',
+      role: 'admin',
+      is_active: true,
+      created_at: '2024-01-01',
+    };
+    expect(adminUser.role).toBe('admin');
+  });
+
+  it('recognises student role from User object', () => {
+    const studentUser: User = {
+      id: 2,
+      full_name: 'Student User',
+      email: 'student@test.com',
+      role: 'student',
+      is_active: true,
+      created_at: '2024-01-01',
+    };
+    expect(studentUser.role).toBe('student');
+  });
+
+  it('blocks direct URL access to admin routes for students', () => {
+    const allowedRoles = ['admin'];
+    const userRole = 'student';
+    expect(allowedRoles.includes(userRole)).toBe(false);
+  });
+
+  it('admin role is included in allowed roles for admin paths', () => {
+    const allowedRoles = ['student', 'admin'];
+    expect(allowedRoles).toContain('admin');
+  });
+
+  it('updates route access when role changes from student to admin', () => {
+    let accessibleRoutes = [PERMISSIONS.VIEW_STUDENT_DASHBOARD, PERMISSIONS.VIEW_TIMETABLE];
+    expect(accessibleRoutes).toContain(PERMISSIONS.VIEW_STUDENT_DASHBOARD);
+
+    accessibleRoutes = Object.values(PERMISSIONS);
+    expect(accessibleRoutes.length).toBeGreaterThan(5);
   });
 });

--- a/smart-campus-frontend/src/test/setup.ts
+++ b/smart-campus-frontend/src/test/setup.ts
@@ -1,8 +1,36 @@
-import { expect, afterEach } from 'vitest';
+import { beforeAll, afterEach, afterAll } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { server } from './mocks/server';
 
-// Cleanup after each test
+// ─────────────────────────────────────────────────────────────────────────────
+// MSW Server Lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Start the MSW intercept server before any test in the suite runs.
+ *
+ * onUnhandledRequest: 'warn' — logs a warning when a component fires a request
+ * that has no matching handler, helping catch missing mocks without hard-failing.
+ * Switch to 'error' once all routes are covered to enforce strict coverage.
+ */
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' });
+});
+
+/**
+ * After each individual test, reset all handlers back to the defaults
+ * defined in handlers.ts. This prevents per-test overrides (server.use(...))
+ * from leaking into subsequent tests.
+ */
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
+});
+
+/**
+ * Shut down the MSW server cleanly after the entire test suite finishes.
+ */
+afterAll(() => {
+  server.close();
 });


### PR DESCRIPTION


### Summary

Frontend tests previously relied on `vi.mock()` boilerplate scattered across test files, making them brittle and hard to maintain. This PR introduces **Mock Service Worker (MSW)** to intercept API requests at the **network level** — meaning components run their real code paths, but no backend is ever needed.

---

closes issue #201 

### Changes

**New: `src/test/mocks/handlers.ts`**
Centralised mock API registry covering all major routes:
- `auth` — profile, login, register, logout, refresh, change-password
- `timetable` — group schedule, teachers, subjects, rooms, groups, config
- `events`, `electives`, `notifications`, `search`

Also exports reusable `mockStudentUser` and `mockAdminUser` fixtures for use across any test file.

**New: `src/test/mocks/server.ts`**
MSW Node server instance (`setupServer`) that loads all handlers — the single source of truth for mock API behaviour.

**Updated: `src/test/setup.ts`**
Wired MSW into Vitest's global lifecycle:
```
beforeAll  → server.listen()     
afterEach  → server.resetHandlers() 
afterAll   → server.close()        
```

**Refactored: `src/test/protected-route.test.tsx`**
- Removed all `vi.mock()` boilerplate
- Replaced with direct `fetch()` assertions that prove MSW intercepts at the transport layer
- Tests per-test 401 simulation via `server.use(...)` override and verifies handler reset works correctly
- Added proper `AuthProvider + BrowserRouter` provider tree

---

### Result

```
Test Files: 5 passed
     Tests: 82 passed (82)
  Duration: ~23s
```