### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/smart-campus-frontend/e2e/admin.spec.ts
+++ b/smart-campus-frontend/e2e/admin.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin, loginAsStudent, mockApi } from './fixtures';
+
+test('admin can access the admin dashboard', async ({ page }) => {
+  await mockApi(page);
+  await loginAsAdmin(page);
+
+  await page.goto('/admin/dashboard');
+
+  await expect(page).toHaveURL(/\/admin\/dashboard$/);
+  await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
+});
+
+test('student is blocked from the admin dashboard', async ({ page }) => {
+  await mockApi(page);
+  await loginAsStudent(page);
+
+  await page.goto('/admin/dashboard');
+
+  await expect(page).toHaveURL(/\/unauthorized$/);
+  await expect(page.getByRole('heading', { name: 'Access Denied' })).toBeVisible();
+});

--- a/smart-campus-frontend/e2e/auth.spec.ts
+++ b/smart-campus-frontend/e2e/auth.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+import { mockApi } from './fixtures';
+
+test('student can log in and reach the dashboard', async ({ page }) => {
+  await mockApi(page);
+
+  await page.goto('/auth');
+  await page.getByLabel('Email').fill('student@campus.edu');
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  await expect(page).toHaveURL(/\/student\/dashboard$/);
+});

--- a/smart-campus-frontend/e2e/events.spec.ts
+++ b/smart-campus-frontend/e2e/events.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+import { loginAsStudent, mockApi } from './fixtures';
+
+test('student can navigate to events and RSVP', async ({ page }) => {
+  await mockApi(page);
+  await loginAsStudent(page);
+
+  await page.goto('/events');
+  await expect(page.getByRole('heading', { name: 'Campus Events' })).toBeVisible();
+  await expect(page.getByText('Robotics Workshop')).toBeVisible();
+
+  await page.getByRole('button', { name: 'RSVP Now' }).click();
+
+  await expect(page.getByRole('button', { name: 'Already RSVPed' })).toBeVisible();
+});

--- a/smart-campus-frontend/e2e/fixtures.ts
+++ b/smart-campus-frontend/e2e/fixtures.ts
@@ -1,0 +1,134 @@
+import { expect, type Page } from '@playwright/test';
+
+type TestUser = {
+  id: number;
+  full_name: string;
+  email: string;
+  role: 'student' | 'admin';
+  department: string;
+  cgpa?: number;
+  semester?: number;
+  is_active: boolean;
+  created_at: string;
+};
+
+const studentUser: TestUser = {
+  id: 1,
+  full_name: 'Test Student',
+  email: 'student@campus.edu',
+  role: 'student',
+  department: 'Computer Science',
+  cgpa: 8.6,
+  semester: 5,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+const adminUser: TestUser = {
+  id: 2,
+  full_name: 'Test Admin',
+  email: 'admin@campus.edu',
+  role: 'admin',
+  department: 'Administration',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+export async function mockApi(page: Page) {
+  let currentUser: TestUser | null = null;
+  let rsvpStatus: 'confirmed' | null = null;
+
+  const campusEvent = () => ({
+    id: 1,
+    title: 'Robotics Workshop',
+    description: 'Build and test autonomous campus utility prototypes.',
+    location: 'Innovation Lab',
+    start_time: '2026-06-20T10:00:00.000Z',
+    end_time: '2026-06-20T12:00:00.000Z',
+    club_id: 7,
+    club_name: 'Tech Club',
+    target_department: 'Computer Science',
+    is_featured: true,
+    tags: ['workshop', 'robotics'],
+    max_capacity: 40,
+    current_confirmed: rsvpStatus ? 1 : 0,
+    rsvp_status: rsvpStatus,
+  });
+
+  await page.route('**/api/auth/profile', async (route) => {
+    if (!currentUser) {
+      await route.fulfill({ status: 401, json: { success: false, message: 'Not authenticated' } });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      json: { success: true, message: 'Profile fetched', data: { user: currentUser } },
+    });
+  });
+
+  await page.route('**/api/auth/login', async (route) => {
+    const body = route.request().postDataJSON() as { email?: string };
+    currentUser = body.email === adminUser.email ? adminUser : studentUser;
+
+    await route.fulfill({
+      status: 200,
+      json: { success: true, message: 'Login successful', data: { user: currentUser } },
+    });
+  });
+
+  await page.route('**/api/auth/refresh', async (route) => {
+    await route.fulfill({ status: 401, json: { success: false, message: 'Session expired' } });
+  });
+
+  await page.route('**/api/events/saved/my-events', async (route) => {
+    await route.fulfill({
+      status: 200,
+      json: { success: true, message: 'Saved events fetched', data: { events: [], count: 0 } },
+    });
+  });
+
+  await page.route('**/api/events/1/rsvp', async (route) => {
+    rsvpStatus = 'confirmed';
+
+    await route.fulfill({
+      status: 200,
+      json: {
+        success: true,
+        message: 'RSVP successful',
+        data: { rsvp: { event_id: 1, status: rsvpStatus } },
+      },
+    });
+  });
+
+  await page.route('**/api/events?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      json: { success: true, message: 'Events fetched', data: { events: [campusEvent()], total: 1 } },
+    });
+  });
+
+  return {
+    setUser(user: TestUser) {
+      currentUser = user;
+    },
+    studentUser,
+    adminUser,
+  };
+}
+
+export async function loginAsStudent(page: Page) {
+  await page.goto('/auth');
+  await page.getByLabel('Email').fill(studentUser.email);
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page).toHaveURL(/\/student\/dashboard$/);
+}
+
+export async function loginAsAdmin(page: Page) {
+  await page.goto('/auth');
+  await page.getByLabel('Email').fill(adminUser.email);
+  await page.getByLabel('Password').fill('admin123');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page).toHaveURL(/\/admin\/dashboard$/);
+}

--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -75,6 +75,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
@@ -1322,6 +1323,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8008,6 +8025,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/smart-campus-frontend/package.json
+++ b/smart-campus-frontend/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "preview": "vite preview",
     "prepare": "husky"
   },
@@ -82,6 +83,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",

--- a/smart-campus-frontend/playwright.config.ts
+++ b/smart-campus-frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
**Changes**
- Installed `@playwright/test` as a frontend dev dependency.
- Added `npm run test:e2e`.
- Added Playwright config to start the Vite dev server before tests.
- Added E2E tests for:
  - Student login and dashboard redirect.
  - Student Events page RSVP flow.
  - Admin dashboard access.
  - Student blocked from admin protected route.
- Added shared E2E API mocks so tests do not require a live backend.

**Verification**
- Could not fully run `npm run test:e2e` locally because the machine ran out of disk space during Playwright package extraction, corrupting local `node_modules/playwright-core`.
- The generated/corrupted Playwright `node_modules` folders were removed only to free disk space so Git could stage and commit. This does not affect committed source files.

**Outside Issue Scope**
- No intentional source changes outside the requested Playwright E2E setup.
- Only cleanup outside the issue was deleting corrupted generated dependency folders from `node_modules`, required because disk space failure prevented Git from staging the commit.

Closes #219