### PR TITLE
Feature/playwright e2e tests

### DIFF
--- a/smart-campus-frontend/e2e/admin.spec.ts
+++ b/smart-campus-frontend/e2e/admin.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, loginAsStudent, mockApi } from './fixtures';
+
+test('admin can access the admin dashboard', async ({ page }) => {
+  await mockApi(page);
+  await loginAsAdmin(page);
+  await page.goto('/admin');
+  await expect(page).toHaveURL(/admin/);
+});
+
+test('student cannot access the admin dashboard', async ({ page }) => {
+  await mockApi(page);
+  await loginAsStudent(page);
+  await page.goto('/admin');
+  await expect(page).not.toHaveURL(/admin/);
+});

--- a/smart-campus-frontend/e2e/auth.spec.ts
+++ b/smart-campus-frontend/e2e/auth.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+import { mockApi } from './fixtures';
+
+test('student can log in and reach the dashboard', async ({ page }) => {
+  await mockApi(page);
+  await page.goto('/');
+  await page.fill('input[name="email"]', 'student@campus.edu');
+  await page.fill('input[name="password"]', 'password123');
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(/dashboard/);
+});

--- a/smart-campus-frontend/e2e/events.spec.ts
+++ b/smart-campus-frontend/e2e/events.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import { loginAsStudent, mockApi } from './fixtures';
+
+test('student can navigate to events and RSVP', async ({ page }) => {
+  await mockApi(page);
+  await loginAsStudent(page);
+  await page.click('a[href*="events"]');
+  await expect(page).toHaveURL(/events/);
+  const rsvpButton = page.getByRole('button', { name: /rsvp/i });
+  await rsvpButton.first().click();
+  await expect(rsvpButton.first()).toBeVisible();
+});

--- a/smart-campus-frontend/e2e/fixtures.ts
+++ b/smart-campus-frontend/e2e/fixtures.ts
@@ -1,0 +1,27 @@
+import { Page } from '@playwright/test';
+
+export async function mockApi(page: Page) {
+  await page.route('**/api/**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+}
+
+export async function loginAsStudent(page: Page) {
+  await page.goto('/');
+  await page.fill('input[name="email"]', 'student@campus.edu');
+  await page.fill('input[name="password"]', 'password123');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard**');
+}
+
+export async function loginAsAdmin(page: Page) {
+  await page.goto('/');
+  await page.fill('input[name="email"]', 'admin@campus.edu');
+  await page.fill('input[name="password"]', 'admin123');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard**');
+}

--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -75,6 +75,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
@@ -1322,6 +1323,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8008,6 +8025,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/smart-campus-frontend/package.json
+++ b/smart-campus-frontend/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
@@ -101,7 +102,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^7.3.3"
+    "vite": "^7.3.3",
+    "@playwright/test": "^1.45.0"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [
@@ -113,3 +115,4 @@
     ]
   }
 }
+

--- a/smart-campus-frontend/playwright.config.ts
+++ b/smart-campus-frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/smart-campus-frontend/vitest.config.ts
+++ b/smart-campus-frontend/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    exclude: ['**/node_modules/**', 'e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
Closes #219

Integrates Microsoft Playwright into the frontend and adds automated E2E test suites for critical user journeys.

## Changes
- Added `playwright.config.ts` with Chromium setup and Vite dev server integration
- Created `e2e/fixtures.ts` with reusable `mockApi`, `loginAsStudent`, and `loginAsAdmin` helpers
- Added 3 E2E test suites:
  - `e2e/auth.spec.ts` — student login and dashboard redirect
  - `e2e/events.spec.ts` — navigate to events page and RSVP
  - `e2e/admin.spec.ts` — admin access to protected route, student blocked from admin

## Testing
- Vitest unit tests: ✅ 85 passed
- Playwright E2E tests: ✅ configured and ready to run via `npm run test:e2e`

## How to run locally
```bash
npm run test:e2e
```