### PR TITLE
feat(frontend): implement active sessions list UI and remote revocati…

### DIFF
--- a/smart-campus-frontend/package-lock.json
+++ b/smart-campus-frontend/package-lock.json
@@ -170,7 +170,6 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -322,6 +321,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -366,6 +366,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2826,6 +2827,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -3512,7 +3514,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3532,7 +3533,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3541,8 +3541,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -3600,8 +3599,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3706,6 +3704,7 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3727,6 +3726,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3738,6 +3738,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3779,6 +3780,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
       "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3841,6 +3843,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -4179,6 +4182,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4493,6 +4497,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5134,6 +5139,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5198,7 +5204,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5283,7 +5288,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5481,6 +5487,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6307,6 +6314,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -6579,6 +6587,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -7482,7 +7491,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7663,6 +7671,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -8029,6 +8038,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8190,7 +8200,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8205,7 +8214,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8215,7 +8223,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8227,8 +8234,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -8300,6 +8306,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8338,6 +8345,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8382,6 +8390,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9319,6 +9328,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9385,7 +9395,8 @@
       "version": "0.160.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
       "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -9662,6 +9673,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9859,6 +9871,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/smart-campus-frontend/src/pages/student/Profile.tsx
+++ b/smart-campus-frontend/src/pages/student/Profile.tsx
@@ -7,10 +7,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FormModal } from '@/components/modals/FormModal';
 import { AvatarCropModal } from '@/components/modals/AvatarCropModal';
-import { User, Lock, Mail, GraduationCap, Camera } from 'lucide-react';
+import { User, Lock, Mail, GraduationCap, Camera, Laptop, Smartphone, Globe, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { authService } from '@/services/authService';
-import { ApiError, UserFormData } from '@/types';
+import { ApiError, UserFormData, UserSession } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function Profile() {
@@ -18,6 +18,10 @@ export default function Profile() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
+
+  // Sessions state
+  const [sessions, setSessions] = useState<UserSession[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
 
   // Avatar crop state
   const [isCropModalOpen, setIsCropModalOpen] = useState(false);
@@ -130,6 +134,68 @@ export default function Profile() {
     } catch (error: unknown) {
       const err = error as ApiError;
       toast.error(err?.message || 'Failed to change password');
+    }
+  };
+
+  const fetchSessions = async () => {
+    try {
+      const response = await authService.getSessions();
+      if (response?.success && response.data) {
+        setSessions(response.data.sessions);
+      }
+    } catch (error) {
+      console.error('Failed to load active sessions:', error);
+    } finally {
+      setSessionsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
+
+  const handleRevokeSession = async (sessionId: number) => {
+    try {
+      const response = await authService.revokeSession(sessionId);
+      if (response?.success) {
+        toast.success('Session revoked successfully!');
+        setSessions(prev => prev.filter(s => s.id !== sessionId));
+      } else {
+        toast.error(response?.message || 'Failed to revoke session');
+      }
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to revoke session');
+    }
+  };
+
+  const getDeviceIcon = (deviceType: string) => {
+    const type = deviceType.toLowerCase();
+    if (type.includes('phone') || type.includes('mobile') || type.includes('ios') || type.includes('android')) {
+      return <Smartphone className="h-5 w-5" />;
+    }
+    if (type.includes('windows') || type.includes('mac') || type.includes('linux') || type.includes('chrome')) {
+      return <Laptop className="h-5 w-5" />;
+    }
+    return <Globe className="h-5 w-5" />;
+  };
+
+  const formatLastActive = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      const diffMs = Date.now() - date.getTime();
+      const diffMins = Math.floor(diffMs / 60000);
+      if (diffMins < 1) return 'Just now';
+      if (diffMins < 60) return `${diffMins}m ago`;
+      const diffHours = Math.floor(diffMins / 60);
+      if (diffHours < 24) return `${diffHours}h ago`;
+      return date.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch (e) {
+      return 'Unknown';
     }
   };
 
@@ -258,6 +324,78 @@ export default function Profile() {
                 </motion.button>
               </Button>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Active Sessions */}
+        <Card className="glass mt-6">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Lock className="h-5 w-5 text-primary" />
+              Active Sessions
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Devices and locations currently accessing your account. Revoke any unfamiliar sessions.
+            </p>
+          </CardHeader>
+          <CardContent>
+            {sessionsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : sessions.length === 0 ? (
+              <p className="text-muted-foreground text-center py-6">No active sessions found.</p>
+            ) : (
+              <div className="space-y-4 divide-y divide-border">
+                {sessions.map((session, index) => (
+                  <motion.div
+                    key={session.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                    className={`flex items-center justify-between gap-4 pt-4 ${index === 0 ? 'pt-0' : ''}`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 bg-primary/10 rounded-lg text-primary mt-1">
+                        {getDeviceIcon(session.device_type)}
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <p className="font-semibold">{session.device_type}</p>
+                          {session.is_current && (
+                            <span className="bg-primary/20 text-primary text-xs px-2 py-0.5 rounded-full font-medium">
+                              Current Session
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-0.5 flex-wrap">
+                          <Globe className="h-3.5 w-3.5" />
+                          {session.location} • {session.ip_address}
+                        </p>
+                        <p className="text-xs text-muted-foreground/85 mt-0.5">
+                          Last active: {formatLastActive(session.last_active)}
+                        </p>
+                      </div>
+                    </div>
+
+                    {!session.is_current && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleRevokeSession(session.id)}
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                        asChild
+                      >
+                        <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                          <Trash2 className="h-4 w-4 mr-1.5" />
+                          Revoke
+                        </motion.button>
+                      </Button>
+                    )}
+                  </motion.div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       </motion.div>

--- a/smart-campus-frontend/src/services/authService.ts
+++ b/smart-campus-frontend/src/services/authService.ts
@@ -1,6 +1,6 @@
 import { api } from '@/lib/axios';
 import { withServiceError } from './serviceUtils';
-import { User, ApiResponse, ApiError, UserRole } from '@/types';
+import { User, ApiResponse, ApiError, UserRole, UserSession } from '@/types';
 import { AxiosError } from 'axios';
 
 export interface LoginRequest {
@@ -297,6 +297,30 @@ export const authService = {
           axiosError.message || 
           'Failed to reset password. Please check your information and try again.';
         throw { message: errorMessage } as ApiError;
+      }
+    },
+
+    /**
+     * Get all active sessions for the current user
+     */
+    getSessions: async (): Promise<ApiResponse<{ sessions: UserSession[] }>> => {
+      try {
+        const { data } = await api.get<ApiResponse<{ sessions: UserSession[] }>>('/auth/sessions');
+        return data;
+      } catch (error) {
+        withServiceError(error, 'Failed to fetch active sessions');
+      }
+    },
+
+    /**
+     * Revoke an active session by ID
+     */
+    revokeSession: async (sessionId: number): Promise<ApiResponse<null>> => {
+      try {
+        const { data } = await api.delete<ApiResponse<null>>(`/auth/sessions/${sessionId}`);
+        return data;
+      } catch (error) {
+        withServiceError(error, 'Failed to revoke session');
       }
     }
 };

--- a/smart-campus-frontend/src/types/index.ts
+++ b/smart-campus-frontend/src/types/index.ts
@@ -184,3 +184,14 @@ export interface Club {
   category: string;
   image_url?: string;
 }
+
+export interface UserSession {
+  id: number;
+  ip_address: string;
+  user_agent: string;
+  device_type: string;
+  location: string;
+  last_active: string;
+  created_at: string;
+  is_current: boolean;
+}


### PR DESCRIPTION


### Description

This PR adds the **"Where am I logged in?"** UI to the student Profile page. Users can see all devices currently accessing their account with location, IP, and last-active time — and revoke any unfamiliar session with a single click.

### Changes

#### `src/types/index.ts`
- Added `UserSession` interface:
  ```ts
  interface UserSession {
    id: number;
    ip_address: string;
    user_agent: string;
    device_type: string;      // "desktop", "mobile", etc.
    location: string;          // "Mumbai, Maharashtra, India"
    last_active: string;       // ISO timestamp
    created_at: string;
    is_current: boolean;       // true if this is the active session
  }
  ```

#### `src/services/authService.ts`
- Imported `UserSession` type
- Added two new service methods:
  - `getSessions()` → `GET /auth/sessions` — fetches all active sessions for the logged-in user
  - `revokeSession(sessionId)` → `DELETE /auth/sessions/:id` — revokes a specific session by ID

#### `src/pages/student/Profile.tsx`
- Added state: `sessions: UserSession[]` + `sessionsLoading: boolean`
- `fetchSessions()` called on mount via `useEffect` to load sessions from API
- `handleRevokeSession(sessionId)` — calls `revokeSession`, removes the entry from state optimistically, shows a `toast.success` / `toast.error`
- `getDeviceIcon(deviceType)` — returns `<Laptop>`, `<Smartphone>`, or `<Globe>` icon based on device type string
- `formatLastActive(dateString)` — human-readable relative time:
  - `< 1min` → "Just now"
  - `< 60min` → "15m ago"
  - `< 24h` → "3h ago"
  - Older → "Jun 9, 03:30 AM"
- New **"Active Sessions"** card rendered below the existing profile sections:
  - Loading spinner while fetching
  - "No active sessions found" empty state
  - Each session row shows:
    - Device icon + device type label
    - **"Current Session"** badge (green pill) for the active session
    - Location + IP address
    - Last active relative timestamp
    - **Revoke** button (red, destructive) — hidden for current session
  - Animated entry using `framer-motion` (`opacity 0→1`, `y 10→0`, staggered by index)

