### PR TITLE
feat(feedback): add Report a Bug widget with Discord webhook integration

### DIFF
--- a/smart-campus-backend/.env.example
+++ b/smart-campus-backend/.env.example
@@ -85,3 +85,10 @@ MAILTRAP_PASSWORD=your_mailtrap_password
 
 # Password Reset Token Expiry (in minutes)
 PASSWORD_RESET_EXPIRY_MINUTES=15
+
+# -----------------------------------------------
+# Discord Webhook (Bug Report Widget)
+# Create a webhook in your Discord server:
+# Server Settings > Integrations > Webhooks > New Webhook
+# -----------------------------------------------
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_id/your_webhook_token

--- a/smart-campus-backend/src/app.js
+++ b/smart-campus-backend/src/app.js
@@ -43,6 +43,7 @@ const notificationsRoutes = require("./components/notifications/notifications.ro
 const searchRoutes = require("./components/search/search.routes");
 const activityRoutes = require("./components/activities/activity.routes");
 const calendarRoutes = require('./components/calendar/calendar.routes');
+const feedbackRoutes = require('./components/feedback/feedback.routes');
 
 // Create Express application
 const app = express();
@@ -145,6 +146,7 @@ app.use('/api/notifications', notificationsRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/activities', activityRoutes);
 app.use('/api/calendar',   calendarRoutes);
+app.use('/api/feedback', feedbackRoutes);
 
 // Test Socket endpoint
 app.get('/api/test-socket', verifyToken, verifyAdmin, (req, res) => {

--- a/smart-campus-backend/src/components/feedback/feedback.controller.js
+++ b/smart-campus-backend/src/components/feedback/feedback.controller.js
@@ -1,0 +1,50 @@
+const { sendSuccess, sendError } = require('../../utils/response');
+const { logger } = require('../../config/db');
+
+const submitFeedback = async (req, res) => {
+  const { description, page } = req.body;
+  const { email, role } = req.user;
+
+  if (!description || !description.trim()) {
+    return sendError(res, 400, 'Bug description is required');
+  }
+
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+  if (!webhookUrl) {
+    logger.warn('DISCORD_WEBHOOK_URL is not configured');
+    return sendError(res, 503, 'Feedback service is not configured');
+  }
+
+  const embed = {
+    title: '🐛 New Bug Report',
+    color: 0xe74c3c,
+    fields: [
+      { name: '👤 Reported By', value: email, inline: true },
+      { name: '🎭 Role', value: role, inline: true },
+      { name: '📄 Page', value: page || 'Unknown', inline: true },
+      { name: '📝 Description', value: description.trim() },
+    ],
+    timestamp: new Date().toISOString(),
+    footer: { text: 'Smart Campus Utility Hub' },
+  };
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [embed] }),
+    });
+
+    if (!response.ok) {
+      logger.error('Discord webhook failed', { status: response.status });
+      return sendError(res, 502, 'Failed to send feedback to Discord');
+    }
+
+    return sendSuccess(res, 200, 'Bug report submitted successfully');
+  } catch (error) {
+    logger.error('Discord webhook error:', error);
+    return sendError(res, 500, 'Failed to submit bug report');
+  }
+};
+
+module.exports = { submitFeedback };

--- a/smart-campus-backend/src/components/feedback/feedback.routes.js
+++ b/smart-campus-backend/src/components/feedback/feedback.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { verifyToken } = require('../../middleware/auth.middleware');
+const { submitFeedback } = require('./feedback.controller');
+
+router.post('/', verifyToken, submitFeedback);
+
+module.exports = router;

--- a/smart-campus-frontend/src/components/layout/DashboardLayout.tsx
+++ b/smart-campus-frontend/src/components/layout/DashboardLayout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
+import { BugReportWidget } from '../ui/BugReportWidget';
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
           {children}
         </ErrorBoundary>
       </main>
+      <BugReportWidget />
     </div>
   );
 };

--- a/smart-campus-frontend/src/components/ui/BugReportWidget.tsx
+++ b/smart-campus-frontend/src/components/ui/BugReportWidget.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Bug, X, Send } from 'lucide-react';
+import api from '@/lib/axios';
+
+export const BugReportWidget = () => {
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!description.trim()) return;
+
+    try {
+      setIsSubmitting(true);
+      await api.post('/feedback', {
+        description: description.trim(),
+        page: window.location.pathname,
+      });
+      toast.success('Bug report sent! Thanks for helping us improve. 🐛');
+      setDescription('');
+      setOpen(false);
+    } catch {
+      toast.error('Failed to send bug report. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Floating trigger button */}
+      <button
+        onClick={() => setOpen(true)}
+        title="Report a bug"
+        className="fixed bottom-6 right-6 z-50 w-12 h-12 rounded-full bg-red-500 hover:bg-red-600 text-white shadow-lg flex items-center justify-center transition-colors"
+      >
+        <Bug size={20} />
+      </button>
+
+      {/* Modal overlay */}
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end justify-end p-6">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setOpen(false)}
+          />
+          <div className="relative bg-background border rounded-xl shadow-2xl w-full max-w-sm p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-base flex items-center gap-2">
+                <Bug size={16} className="text-red-500" />
+                Report a Bug
+              </h3>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe what went wrong..."
+                rows={4}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-500"
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground text-right">
+                {description.length}/500
+              </p>
+              <button
+                type="submit"
+                disabled={isSubmitting || !description.trim() || description.length > 500}
+                className="w-full flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white rounded-md py-2 text-sm font-medium transition-colors"
+              >
+                <Send size={14} />
+                {isSubmitting ? 'Sending...' : 'Send Report'}
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
Closes #216

What's changed

Backend

- New POST /api/feedback endpoint (auth required) in src/components/feedback/
- Formats a rich Discord embed with reporter's email, role, current page, and bug description
- Performs a server-to-server POST to DISCORD_WEBHOOK_URL — the webhook URL never reaches the client
- Returns proper error codes: 400 (missing description), 503 (webhook not configured), 502 (Discord error)
- Added DISCORD_WEBHOOK_URL to .env.example with setup instructions

Frontend

- Floating 🐛 button fixed to the bottom-right corner of every dashboard page
- Opens a modal with a textarea, 500-char counter, and Send button
- Sends description + window.location.pathname to the backend
- Success/error feedback via sonner toast
- Widget mounted in DashboardLayout so it's available on all authenticated pages

How to test

1. Add DISCORD_WEBHOOK_URL=<your webhook> to smart-campus-backend/.env
2. Log in as any user, click the 🐛 button, describe a bug, hit Send
3. Check your Discord channel for the formatted embed