### PR TITLE
feat(events): allow users to cancel event registrations

### DIFF
--- a/smart-campus-backend/src/components/campus-events/events.controller.js
+++ b/smart-campus-backend/src/components/campus-events/events.controller.js
@@ -511,6 +511,55 @@ const rsvpToEvent = asyncHandler(async (req, res) => {
 });
 
 /**
+ * Cancel RSVP for an Event (Protected)
+ * DELETE /api/events/:id/rsvp
+ */
+const cancelRsvpToEvent = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const userId = req.user.id;
+
+  const eventId = parseInt(id);
+  if (isNaN(eventId) || eventId < 1) {
+    throw new ApiError(400, 'Invalid event ID');
+  }
+
+  // 1. Fetch Event
+  const eventCheck = await query('SELECT id, title FROM events WHERE id = $1 AND deleted_at IS NULL', [eventId]);
+  if (eventCheck.rows.length === 0) {
+    throw new ApiError(404, 'Event not found');
+  }
+  const event = eventCheck.rows[0];
+
+  // 2. Check if RSVP exists
+  const rsvpCheck = await query(
+    'SELECT id, status FROM event_rsvps WHERE user_id = $1 AND event_id = $2',
+    [userId, eventId]
+  );
+  if (rsvpCheck.rows.length === 0) {
+    throw new ApiError(400, 'You are not registered for this event');
+  }
+  const rsvp = rsvpCheck.rows[0];
+
+  // 3. Delete the RSVP record
+  await query('DELETE FROM event_rsvps WHERE user_id = $1 AND event_id = $2', [userId, eventId]);
+
+  logger.info('Event RSVP cancelled', { eventId, userId });
+
+  // 4. Log Dynamic Tracking Activity Logs
+  await activityService.logActivity({
+    userId,
+    action: 'CANCEL_RSVP',
+    entityType: 'event_rsvp',
+    entityId: rsvp.id,
+    description: `Successfully cancelled registration for event: ${event.title}`,
+    metadata: { eventId, status: rsvp.status }
+  });
+
+  // 5. Send Success response
+  sendSuccess(res, 200, 'Registration cancelled successfully');
+});
+
+/**
  * Restore a soft-deleted event (Admin only)
  * POST /api/events/:id/restore
  */
@@ -545,4 +594,5 @@ module.exports = {
   unsaveEvent,
   getSavedEvents,
   rsvpToEvent,
+  cancelRsvpToEvent,
 };

--- a/smart-campus-backend/src/components/campus-events/events.routes.js
+++ b/smart-campus-backend/src/components/campus-events/events.routes.js
@@ -44,8 +44,9 @@ router.get('/:id', apiLimiter, validate(validationSchemas.idParam, 'params'), ev
 router.post('/:id/save', verifyToken, validate(validationSchemas.idParam, 'params'), eventsController.saveEvent);
 router.delete('/:id/save', verifyToken, validate(validationSchemas.idParam, 'params'), eventsController.unsaveEvent);
 
-// 🎫 RSVP / Waitlist Endpoint (Added for Issue #194)
+// 🎫 RSVP / Join Waitlist Engine (Added for Issue #194)
 router.post('/:id/rsvp', verifyToken, validate(validationSchemas.idParam, 'params'), eventsController.rsvpToEvent);
+router.delete('/:id/rsvp', verifyToken, validate(validationSchemas.idParam, 'params'), eventsController.cancelRsvpToEvent);
 
 // Admin-only routes — upload.single('image') must match frontend field name
 // Admin-only routes

--- a/smart-campus-frontend/src/pages/student/Events.tsx
+++ b/smart-campus-frontend/src/pages/student/Events.tsx
@@ -10,6 +10,16 @@ import { eventsService, Event } from '@/services/eventService';
 import { useConnectivity } from '@/contexts/ConnectivityContext';
 import { useToast } from '@/components/ui/use-toast';
 import { playSuccessSound } from '@/lib/successSound';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 // Extend Event type internally if properties are missing from standard declaration
 interface ExtendedEvent extends Event {
@@ -26,6 +36,7 @@ export default function EventsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSavingMap, setIsSavingMap] = useState<Map<number, boolean>>(new Map());
   const [isRsvpingMap, setIsRsvpingMap] = useState<Map<number, boolean>>(new Map()); // 🎫 Track RSVP loaders per card
+  const [cancelEventId, setCancelEventId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState({
     search: '',
@@ -121,6 +132,25 @@ export default function EventsPage() {
     } catch (error: unknown) {
       const e = error as { message?: string };
       toast.error(e?.message || 'Failed to process RSVP request');
+    } finally {
+      setIsRsvpingMap(new Map(isRsvpingMap).set(eventId, false));
+    }
+  };
+
+  // 🎫 Handle Event RSVP Cancellation
+  const handleCancelRsvpEvent = async (eventId: number) => {
+    try {
+      setIsRsvpingMap(new Map(isRsvpingMap).set(eventId, true));
+      
+      await eventsService.cancelRsvp(eventId);
+      
+      toast.success('Registration cancelled successfully! ❌');
+
+      // Refresh states locally to re-render badges
+      loadEvents();
+    } catch (error: unknown) {
+      const e = error as { message?: string };
+      toast.error(e?.message || 'Failed to cancel registration');
     } finally {
       setIsRsvpingMap(new Map(isRsvpingMap).set(eventId, false));
     }
@@ -416,32 +446,43 @@ export default function EventsPage() {
 
                 {/* 🎫 Dynamic Fullstack Action Button */}
                 <div className="px-6 pb-6">
-                  <Button
-                    onClick={() => handleRsvpEvent(event.id)}
-                    disabled={isRsvpingMap.get(event.id) || !!userStatus || !isOnline}
-                    className={`w-full font-bold transition-all ${
-                      userStatus 
-                        ? 'bg-secondary text-secondary-foreground cursor-not-allowed'
-                        : isFull 
+                  {userStatus ? (
+                    <Button
+                      onClick={() => setCancelEventId(event.id)}
+                      disabled={isRsvpingMap.get(event.id) || !isOnline}
+                      className="w-full font-bold transition-all bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      {isRsvpingMap.get(event.id) ? (
+                        <>
+                          <Loader className="h-4 w-4 mr-2 animate-spin" />
+                          Processing...
+                        </>
+                      ) : (
+                        'Cancel Registration'
+                      )}
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={() => handleRsvpEvent(event.id)}
+                      disabled={isRsvpingMap.get(event.id) || !isOnline}
+                      className={`w-full font-bold transition-all ${
+                        isFull 
                           ? 'bg-amber-600 hover:bg-amber-700 text-white' 
                           : 'bg-primary text-primary-foreground'
-                    }`}
-                  >
-                    {isRsvpingMap.get(event.id) ? (
-                      <>
-                        <Loader className="h-4 w-4 mr-2 animate-spin" />
-                        Processing...
-                      </>
-                    ) : userStatus === 'confirmed' ? (
-                      'Already RSVPed'
-                    ) : userStatus === 'waitlisted' ? (
-                      'On Waitlist'
-                    ) : isFull ? (
-                      'Join Waitlist'
-                    ) : (
-                      'RSVP Now'
-                    )}
-                  </Button>
+                      }`}
+                    >
+                      {isRsvpingMap.get(event.id) ? (
+                        <>
+                          <Loader className="h-4 w-4 mr-2 animate-spin" />
+                          Processing...
+                        </>
+                      ) : isFull ? (
+                        'Join Waitlist'
+                      ) : (
+                        'RSVP Now'
+                      )}
+                    </Button>
+                  )}
                 </div>
               </Card>
             </motion.div>
@@ -450,6 +491,31 @@ export default function EventsPage() {
           </div>
         )}
       </motion.div>
+
+      <AlertDialog open={cancelEventId !== null} onOpenChange={(open) => { if (!open) setCancelEventId(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Registration?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel your registration for this event? If the event becomes full, you may have to join the waitlist if you decide to register again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setCancelEventId(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (cancelEventId !== null) {
+                  handleCancelRsvpEvent(cancelEventId);
+                  setCancelEventId(null);
+                }
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Yes, Cancel
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </DashboardLayout>
   );
 }

--- a/smart-campus-frontend/src/services/eventService.ts
+++ b/smart-campus-frontend/src/services/eventService.ts
@@ -180,6 +180,15 @@ export const eventsService = {
     }
   },
 
+  cancelRsvp: async (eventId: string | number): Promise<any> => {
+    try {
+      const data = asApiData(await api.delete(`/events/${eventId}/rsvp`));
+      return data;
+    } catch (error) {
+      withServiceError(error, 'Failed to cancel RSVP request');
+    }
+  },
+
   /**
    * Get all saved events for current user
    */


### PR DESCRIPTION
## Related Issue

Closes #250

## Summary

This PR adds support for cancelling event registrations. Users who have already registered for an event can now cancel their registration through a confirmation dialog.

## Changes Made

* Added backend API endpoint for cancelling event RSVPs.
* Added frontend service method for RSVP cancellation.
* Added **Cancel Registration** button for registered users.
* Added confirmation dialog before cancellation.
* Added success and error toast notifications.
* Automatically refreshes event data after successful cancellation.

## Acceptance Criteria

* [x] Cancel Registration button available
* [x] Confirmation dialog before cancellation
* [x] Registration removed successfully
* [x] Registration count updates automatically
* [x] Success notification displayed
* [x] Event state refreshes without page reload

## Files Modified

### Backend

* `events.controller.js`
* `events.routes.js`

### Frontend

* `eventService.ts`
* `Events.tsx`

## Testing

* Verified registered users can cancel registrations.
* Verified confirmation dialog appears before cancellation.
* Verified participant counts update correctly.
* Verified success notifications are shown.
* Verified existing RSVP functionality remains unaffected.
